### PR TITLE
v1.2. Implement FilterDepartmentCommand and SortCommand

### DIFF
--- a/src/main/java/seedu/address/logic/commands/FilterDepartmentCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FilterDepartmentCommand.java
@@ -32,9 +32,9 @@ public class FilterDepartmentCommand extends Command {
     @Override
     public CommandResult execute(Model model, CommandHistory history) {
         requireNonNull(model);
-        model.updateFilteredDepartmentList(predicate);
+        model.updateFilteredPersonList(predicate);
         return new CommandResult(
-                String.format(Messages.MESSAGE_PERSONS_LISTED_OVERVIEW, model.getFilteredDepartmentList().size()));
+                String.format(Messages.MESSAGE_PERSONS_LISTED_OVERVIEW, model.getFilteredPersonList().size()));
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/FilterDepartmentCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FilterDepartmentCommand.java
@@ -1,0 +1,46 @@
+package seedu.address.logic.commands;
+
+import seedu.address.commons.core.Messages;
+import seedu.address.logic.CommandHistory;
+import seedu.address.model.Model;
+import seedu.address.model.person.DepartmentContainsKeywordsPredicate;
+
+import java.util.logging.Filter;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Finds and lists all persons in address book whose department contains any of the argument keywords.
+ * Keyword matching is case insensitive.
+ */
+public class FilterDepartmentCommand extends Command {
+
+    public static final String COMMAND_WORD = "filterdepartment";
+    public static final String COMMAND_ALIAS = "fd";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all persons whose department contain any of "
+            + "the specified keywords (case-insensitive) and displays them as a list with index numbers.\n"
+            + "Parameters: KEYWORD [MORE_KEYWORDS]...\n"
+            + "Example: " + COMMAND_WORD + " junior management";
+
+    private final DepartmentContainsKeywordsPredicate predicate;
+
+    public FilterDepartmentCommand(DepartmentContainsKeywordsPredicate predicate) {
+        this.predicate = predicate;
+    }
+
+    @Override
+    public CommandResult execute(Model model, CommandHistory history) {
+        requireNonNull(model);
+        model.updateFilteredDepartmentList(predicate);
+        return new CommandResult(
+                String.format(Messages.MESSAGE_PERSONS_LISTED_OVERVIEW, model.getFilteredDepartmentList().size()));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof FilterDepartmentCommand // instanceof handles nulls
+                && predicate.equals(((FilterDepartmentCommand) other).predicate)); // state check
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/FilterDepartmentCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FilterDepartmentCommand.java
@@ -7,6 +7,7 @@ import seedu.address.logic.CommandHistory;
 import seedu.address.model.Model;
 import seedu.address.model.person.DepartmentContainsKeywordsPredicate;
 
+//@@author Woonhian
 /**
  * Finds and lists all persons in address book whose department contains any of the argument keywords.
  * Keyword matching is case insensitive.

--- a/src/main/java/seedu/address/logic/commands/FilterDepartmentCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FilterDepartmentCommand.java
@@ -1,13 +1,11 @@
 package seedu.address.logic.commands;
 
+import static java.util.Objects.requireNonNull;
+
 import seedu.address.commons.core.Messages;
 import seedu.address.logic.CommandHistory;
 import seedu.address.model.Model;
 import seedu.address.model.person.DepartmentContainsKeywordsPredicate;
-
-import java.util.logging.Filter;
-
-import static java.util.Objects.requireNonNull;
 
 /**
  * Finds and lists all persons in address book whose department contains any of the argument keywords.
@@ -20,8 +18,9 @@ public class FilterDepartmentCommand extends Command {
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all persons whose department contain any of "
             + "the specified keywords (case-insensitive) and displays them as a list with index numbers.\n"
+            + "The keyword 'management' will not be accepted as it will list out all of the departments.\n"
             + "Parameters: KEYWORD [MORE_KEYWORDS]...\n"
-            + "Example: " + COMMAND_WORD + " junior management";
+            + "Example: " + COMMAND_WORD + " junior";
 
     private final DepartmentContainsKeywordsPredicate predicate;
 

--- a/src/main/java/seedu/address/logic/commands/FilterDepartmentCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FilterDepartmentCommand.java
@@ -18,7 +18,7 @@ public class FilterDepartmentCommand extends Command {
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all persons whose department contain any of "
             + "the specified keywords (case-insensitive) and displays them as a list with index numbers.\n"
-            + "The keyword 'management' will not be accepted as it will list out all of the departments.\n"
+            + "The keyword 'management' will not be accepted to prevent listing out of all departments.\n"
             + "Parameters: KEYWORD [MORE_KEYWORDS]...\n"
             + "Example: " + COMMAND_WORD + " junior";
 

--- a/src/main/java/seedu/address/logic/commands/SortCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SortCommand.java
@@ -8,6 +8,7 @@ import seedu.address.model.Model;
 import seedu.address.model.person.exceptions.NoEmployeeException;
 
 
+//@@author Woonhian
 /**
  * Sort all employees in address book by name or department in ascending or descending order.
  */

--- a/src/main/java/seedu/address/logic/commands/SortCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SortCommand.java
@@ -1,0 +1,57 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+
+import seedu.address.logic.CommandHistory;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.person.exceptions.NoEmployeeException;
+
+
+/**
+ * Sort all employees in address book by name or department in ascending or descending order.
+ */
+public class SortCommand extends Command {
+
+    public static final String COMMAND_WORD = "sort";
+    public static final String BY_ASCENDING = "asc";
+    public static final String BY_DESCENDING = "desc";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Sorts all employees in Bank Address Book "
+            + "by name or department in ascending or descending order.\n"
+            + "Parameters: KEYWORD [FIELD] [ORDER]\n"
+            + "Example to sort by name in ascending order: " + COMMAND_WORD + " name " + BY_ASCENDING
+            + "\nExample to sort department in descending order: " + COMMAND_WORD + " department " + BY_DESCENDING;
+
+    public static final String MESSAGE_SUCCESS = "Bank Address Book has been sorted!";
+    public static final String MESSAGE_EMPTY_BOOK = "No person to sort";
+
+    private final String field;
+    private final String order;
+
+    public SortCommand(String field, String order) {
+        requireNonNull(field);
+        requireNonNull(order);
+
+        this.field = field;
+        this.order = order;
+    }
+
+    public String getField() {
+        return this.field;
+    }
+
+    public String getOrder() {
+        return this.order;
+    }
+
+    @Override
+    public CommandResult execute(Model model, CommandHistory history) throws CommandException {
+        try {
+            model.sortEmployee(getField(), getOrder());
+        } catch (NoEmployeeException nee) {
+            throw new CommandException(MESSAGE_EMPTY_BOOK);
+        }
+        return new CommandResult(MESSAGE_SUCCESS);
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -15,6 +15,7 @@ import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.ExitCommand;
+import seedu.address.logic.commands.FilterDepartmentCommand;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.HistoryCommand;
@@ -72,6 +73,10 @@ public class AddressBookParser {
 
         case FindCommand.COMMAND_WORD:
             return new FindCommandParser().parse(arguments);
+
+            case FilterDepartmentCommand.COMMAND_WORD:
+            case FilterDepartmentCommand.COMMAND_ALIAS:
+                return new FilterDepartmentCommandParser().parse(arguments);
 
         case ListCommand.COMMAND_WORD:
             return new ListCommand();

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -26,6 +26,7 @@ import seedu.address.logic.commands.RedoCommand;
 import seedu.address.logic.commands.ScheduleCommand;
 import seedu.address.logic.commands.SelectCommand;
 import seedu.address.logic.commands.SetScheduleCommand;
+import seedu.address.logic.commands.SortCommand;
 import seedu.address.logic.commands.UndoCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
@@ -104,6 +105,9 @@ public class AddressBookParser {
 
         case AddLeaveCommand.COMMAND_WORD:
             return new AddLeaveParser().parse(arguments);
+
+            case SortCommand.COMMAND_WORD:
+                return new SortCommandParser().parse(arguments);
 
         case LoginCommand.COMMAND_WORD:
             return new LoginCommandParser().parse(arguments);

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -106,8 +106,8 @@ public class AddressBookParser {
         case AddLeaveCommand.COMMAND_WORD:
             return new AddLeaveParser().parse(arguments);
 
-            case SortCommand.COMMAND_WORD:
-                return new SortCommandParser().parse(arguments);
+        case SortCommand.COMMAND_WORD:
+            return new SortCommandParser().parse(arguments);
 
         case LoginCommand.COMMAND_WORD:
             return new LoginCommandParser().parse(arguments);

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -74,9 +74,9 @@ public class AddressBookParser {
         case FindCommand.COMMAND_WORD:
             return new FindCommandParser().parse(arguments);
 
-            case FilterDepartmentCommand.COMMAND_WORD:
-            case FilterDepartmentCommand.COMMAND_ALIAS:
-                return new FilterDepartmentCommandParser().parse(arguments);
+        case FilterDepartmentCommand.COMMAND_WORD:
+        case FilterDepartmentCommand.COMMAND_ALIAS:
+            return new FilterDepartmentCommandParser().parse(arguments);
 
         case ListCommand.COMMAND_WORD:
             return new ListCommand();

--- a/src/main/java/seedu/address/logic/parser/FilterDepartmentCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FilterDepartmentCommandParser.java
@@ -20,8 +20,9 @@ public class FilterDepartmentCommandParser implements Parser<FilterDepartmentCom
      */
     public FilterDepartmentCommand parse(String args) throws ParseException {
         String trimmedArgs = args.trim();
-        trimmedArgs = trimmedArgs.replaceAll("(?i)management", "");
-        if (trimmedArgs.isEmpty()) {
+        trimmedArgs = trimmedArgs.toLowerCase();
+        //trimmedArgs = trimmedArgs.replaceAll("(?i)management", "");
+        if (trimmedArgs.isEmpty() || trimmedArgs.contains("management")) {
             throw new ParseException(
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, FilterDepartmentCommand.MESSAGE_USAGE));
         }

--- a/src/main/java/seedu/address/logic/parser/FilterDepartmentCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FilterDepartmentCommandParser.java
@@ -21,7 +21,6 @@ public class FilterDepartmentCommandParser implements Parser<FilterDepartmentCom
     public FilterDepartmentCommand parse(String args) throws ParseException {
         String trimmedArgs = args.trim();
         trimmedArgs = trimmedArgs.toLowerCase();
-        //trimmedArgs = trimmedArgs.replaceAll("(?i)management", "");
         if (trimmedArgs.isEmpty() || trimmedArgs.contains("management")) {
             throw new ParseException(
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, FilterDepartmentCommand.MESSAGE_USAGE));

--- a/src/main/java/seedu/address/logic/parser/FilterDepartmentCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FilterDepartmentCommandParser.java
@@ -8,6 +8,7 @@ import seedu.address.logic.commands.FilterDepartmentCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.DepartmentContainsKeywordsPredicate;
 
+//@@author Woonhian
 /**
  * Parses input arguments and creates a new FilterDepartmentCommand object
  */

--- a/src/main/java/seedu/address/logic/parser/FilterDepartmentCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FilterDepartmentCommandParser.java
@@ -1,0 +1,33 @@
+package seedu.address.logic.parser;
+
+import seedu.address.logic.commands.FilterDepartmentCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.person.DepartmentContainsKeywordsPredicate;
+
+import java.util.Arrays;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+/**
+ * Parses input arguments and creates a new FindCommand object
+ */
+public class FilterDepartmentCommandParser implements Parser<FilterDepartmentCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the FindCommand
+     * and returns an FindCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public FilterDepartmentCommand parse(String args) throws ParseException {
+        String trimmedArgs = args.trim();
+        if (trimmedArgs.isEmpty()) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, FilterDepartmentCommand.MESSAGE_USAGE));
+        }
+
+        String[] departmentKeywords = trimmedArgs.split("\\s+");
+
+        return new FilterDepartmentCommand(new DepartmentContainsKeywordsPredicate(Arrays.asList(departmentKeywords)));
+    }
+
+}

--- a/src/main/java/seedu/address/logic/parser/FilterDepartmentCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FilterDepartmentCommandParser.java
@@ -1,25 +1,26 @@
 package seedu.address.logic.parser;
 
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import java.util.Arrays;
+
 import seedu.address.logic.commands.FilterDepartmentCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.DepartmentContainsKeywordsPredicate;
 
-import java.util.Arrays;
-
-import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-
 /**
- * Parses input arguments and creates a new FindCommand object
+ * Parses input arguments and creates a new FilterDepartmentCommand object
  */
 public class FilterDepartmentCommandParser implements Parser<FilterDepartmentCommand> {
 
     /**
-     * Parses the given {@code String} of arguments in the context of the FindCommand
-     * and returns an FindCommand object for execution.
+     * Parses the given {@code String} of arguments in the context of the FilterDepartmentCommand
+     * and returns an FilterDepartmentCommand object for execution.
      * @throws ParseException if the user input does not conform the expected format
      */
     public FilterDepartmentCommand parse(String args) throws ParseException {
         String trimmedArgs = args.trim();
+        trimmedArgs = trimmedArgs.replaceAll("(?i)management", "");
         if (trimmedArgs.isEmpty()) {
             throw new ParseException(
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, FilterDepartmentCommand.MESSAGE_USAGE));

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -118,6 +118,7 @@ public class ParserUtil {
         return new Email(trimmedEmail);
     }
 
+    //@@author Woonhian
     /**
      * Parses a {@code String department} into a {@code Department}.
      * Leading and trailing whitespaces will be trimmed.

--- a/src/main/java/seedu/address/logic/parser/SortCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/SortCommandParser.java
@@ -2,13 +2,12 @@ package seedu.address.logic.parser;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 
-import seedu.address.logic.commands.SortCommand;
-import seedu.address.logic.parser.exceptions.ParseException;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import seedu.address.logic.commands.SortCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
 
 /**
  * Parses input arguments and creates a new SortCommand object

--- a/src/main/java/seedu/address/logic/parser/SortCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/SortCommandParser.java
@@ -1,5 +1,7 @@
 package seedu.address.logic.parser;
 
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
 import seedu.address.logic.commands.SortCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
@@ -7,7 +9,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 
 /**
  * Parses input arguments and creates a new SortCommand object
@@ -31,15 +32,15 @@ public class SortCommandParser implements Parser<SortCommand> {
             argKeywords[i] = argKeywords[i].toLowerCase();
         }
 
-        if(argKeywords.length != 2) {
+        if (argKeywords.length != 2) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, SortCommand.MESSAGE_USAGE));
         }
 
-        if(!ACCEPTED_FIELDS.contains(argKeywords[0])) {
+        if (!ACCEPTED_FIELDS.contains(argKeywords[0])) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, SortCommand.MESSAGE_USAGE));
         }
 
-        if(!ACCEPTED_ORDERS.contains(argKeywords[1])) {
+        if (!ACCEPTED_ORDERS.contains(argKeywords[1])) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, SortCommand.MESSAGE_USAGE));
         }
 

--- a/src/main/java/seedu/address/logic/parser/SortCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/SortCommandParser.java
@@ -1,0 +1,48 @@
+package seedu.address.logic.parser;
+
+import seedu.address.logic.commands.SortCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+/**
+ * Parses input arguments and creates a new SortCommand object
+ */
+public class SortCommandParser implements Parser<SortCommand> {
+
+    public static final List<String> ACCEPTED_FIELDS = new ArrayList<>(Arrays.asList("name", "department"));
+    public static final List<String> ACCEPTED_ORDERS = new ArrayList<>(Arrays.asList("asc", "desc"));
+
+    @Override
+    public SortCommand parse(String args) throws ParseException {
+        String trimmedArgs = args.trim();
+        if (trimmedArgs.isEmpty()) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, SortCommand.MESSAGE_USAGE));
+        }
+
+        String[] argKeywords = trimmedArgs.split("\\s+");
+
+        for (int i = 0; i < argKeywords.length; i++) {
+            argKeywords[i] = argKeywords[i].toLowerCase();
+        }
+
+        if(argKeywords.length != 2) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, SortCommand.MESSAGE_USAGE));
+        }
+
+        if(!ACCEPTED_FIELDS.contains(argKeywords[0])) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, SortCommand.MESSAGE_USAGE));
+        }
+
+        if(!ACCEPTED_ORDERS.contains(argKeywords[1])) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, SortCommand.MESSAGE_USAGE));
+        }
+
+        return new SortCommand(argKeywords[0], argKeywords[1]);
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/SortCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/SortCommandParser.java
@@ -9,6 +9,7 @@ import java.util.List;
 import seedu.address.logic.commands.SortCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
+//@@author Woonhian
 /**
  * Parses input arguments and creates a new SortCommand object
  */

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -7,6 +7,7 @@ import java.util.List;
 import javafx.collections.ObservableList;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.UniquePersonList;
+import seedu.address.model.person.exceptions.NoEmployeeException;
 
 /**
  * Wraps all data at the address-book level
@@ -91,6 +92,14 @@ public class AddressBook implements ReadOnlyAddressBook {
      */
     public void removePerson(Person key) {
         persons.remove(key);
+    }
+
+    /**
+     * Sorts employees in the address book by name or department.
+     * Sorting can be done in ascending or descending order.
+     */
+    public void sortEmployeeBy(String field, String order) throws NoEmployeeException {
+        persons.sortBy(field, order);
     }
 
     //// util methods

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -50,20 +50,11 @@ public interface Model {
     /** Returns an unmodifiable view of the filtered person list */
     ObservableList<Person> getFilteredPersonList();
 
-    /** Returns an unmodifiable view of the filtered department list */
-    ObservableList<Person> getFilteredDepartmentList();
-
     /**
      * Updates the filter of the filtered person list to filter by the given {@code predicate}.
      * @throws NullPointerException if {@code predicate} is null.
      */
     void updateFilteredPersonList(Predicate<Person> predicate);
-
-    /**
-     * Updates the filter of the filtered department list to filter by the given {@code predicate}.
-     * @throws NullPointerException if {@code predicate} is null.
-     */
-    void updateFilteredDepartmentList(Predicate<Person> predicate);
 
     /**
      * Returns true if the model has previous address book states to restore.

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -50,11 +50,20 @@ public interface Model {
     /** Returns an unmodifiable view of the filtered person list */
     ObservableList<Person> getFilteredPersonList();
 
+    /** Returns an unmodifiable view of the filtered department list */
+    ObservableList<Person> getFilteredDepartmentList();
+
     /**
      * Updates the filter of the filtered person list to filter by the given {@code predicate}.
      * @throws NullPointerException if {@code predicate} is null.
      */
     void updateFilteredPersonList(Predicate<Person> predicate);
+
+    /**
+     * Updates the filter of the filtered department list to filter by the given {@code predicate}.
+     * @throws NullPointerException if {@code predicate} is null.
+     */
+    void updateFilteredDepartmentList(Predicate<Person> predicate);
 
     /**
      * Returns true if the model has previous address book states to restore.

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -5,6 +5,7 @@ import java.util.function.Predicate;
 import javafx.collections.ObservableList;
 import seedu.address.model.leave.Leave;
 import seedu.address.model.person.Person;
+import seedu.address.model.person.exceptions.NoEmployeeException;
 
 /**
  * The API of the Model component.
@@ -39,6 +40,14 @@ public interface Model {
      */
     void addPerson(Person person);
     void addLeave (Leave leave);
+
+    /**
+     * Sorts players in address book by field in asc or desc order
+     * @param field
+     * @param order
+     */
+    void sortEmployee(String field, String order) throws NoEmployeeException;
+
     /**
      * Replaces the given person {@code target} with {@code editedPerson}.
      * {@code target} must exist in the address book.

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -15,6 +15,7 @@ import seedu.address.commons.events.model.AddressBookChangedEvent;
 import seedu.address.commons.events.model.LeaveListChangedEvent;
 import seedu.address.model.leave.Leave;
 import seedu.address.model.person.Person;
+import seedu.address.model.person.exceptions.NoEmployeeException;
 
 /**
  * Represents the in-memory model of the address book data.
@@ -131,6 +132,12 @@ public class ModelManager extends ComponentManager implements Model {
         requireAllNonNull(target, editedPerson);
 
         versionedAddressBook.updatePerson(target, editedPerson);
+        indicateAddressBookChanged();
+    }
+
+    @Override
+    public void sortEmployee(String field, String order) throws NoEmployeeException {
+        versionedAddressBook.sortEmployeeBy(field, order);
         indicateAddressBookChanged();
     }
 

--- a/src/main/java/seedu/address/model/person/Department.java
+++ b/src/main/java/seedu/address/model/person/Department.java
@@ -36,7 +36,7 @@ public class Department {
      * Returns true if a given string is a valid department name.
      */
     public static boolean isValidDepartment(String test) {
-        return (test.matches(DEPARTMENT_VALIDATION_REGEX) && !test.equals("Management Management"));
+        return (test.matches(DEPARTMENT_VALIDATION_REGEX));
     }
 
 

--- a/src/main/java/seedu/address/model/person/Department.java
+++ b/src/main/java/seedu/address/model/person/Department.java
@@ -10,7 +10,8 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
 public class Department {
 
     public static final String MESSAGE_DEPARTMENT_CONSTRAINTS =
-            "Department names should only contain alphabetic characters and spaces, and it should not be blank";
+            "Department names should only contain alphabetic characters and spaces, and it should not be blank\n"
+            + "Department names should start with a name, and ends with 'Management'";
 
     /*
      * The first character of the address must not be a whitespace,

--- a/src/main/java/seedu/address/model/person/Department.java
+++ b/src/main/java/seedu/address/model/person/Department.java
@@ -3,6 +3,7 @@ package seedu.address.model.person;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.AppUtil.checkArgument;
 
+//@@author Woonhian
 /**
  * Represents a Person's department in the address book.
  * Guarantees: immutable; is valid as declared in {@link #isValidDepartment(String)}

--- a/src/main/java/seedu/address/model/person/Department.java
+++ b/src/main/java/seedu/address/model/person/Department.java
@@ -10,8 +10,7 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
 public class Department {
 
     public static final String MESSAGE_DEPARTMENT_CONSTRAINTS =
-            "Department names should only contain alphabetic characters and spaces, and it should not be blank\n"
-            + "Department names should start with a name, and ends with 'Management'";
+            "Department names should only contain alphabetic characters and spaces, and it should not be blank";
 
     /*
      * The first character of the address must not be a whitespace,

--- a/src/main/java/seedu/address/model/person/Department.java
+++ b/src/main/java/seedu/address/model/person/Department.java
@@ -36,7 +36,7 @@ public class Department {
      * Returns true if a given string is a valid department name.
      */
     public static boolean isValidDepartment(String test) {
-        return (test.matches(DEPARTMENT_VALIDATION_REGEX));
+        return (test.matches(DEPARTMENT_VALIDATION_REGEX)) && !test.equals("Management Management");
     }
 
 

--- a/src/main/java/seedu/address/model/person/Department.java
+++ b/src/main/java/seedu/address/model/person/Department.java
@@ -10,13 +10,14 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
 public class Department {
 
     public static final String MESSAGE_DEPARTMENT_CONSTRAINTS =
-            "Department names should only contain alphanumeric characters and spaces, and it should not be blank";
+            "Department names should only contain alphabetic characters and spaces, and it should not be blank\n"
+            + "Department names should start with a name, and ends with 'Management'";
 
     /*
      * The first character of the address must not be a whitespace,
      * otherwise " " (a blank string) becomes a valid input.
      */
-    public static final String DEPARTMENT_VALIDATION_REGEX = "[\\p{Alnum}][\\p{Alnum} ]*";
+    public static final String DEPARTMENT_VALIDATION_REGEX = "(\\p{Alpha}+ )+Management";
 
     public final String fullDepartment;
 
@@ -35,7 +36,7 @@ public class Department {
      * Returns true if a given string is a valid department name.
      */
     public static boolean isValidDepartment(String test) {
-        return test.matches(DEPARTMENT_VALIDATION_REGEX);
+        return (test.matches(DEPARTMENT_VALIDATION_REGEX) && !test.equals("Management Management"));
     }
 
 

--- a/src/main/java/seedu/address/model/person/DepartmentContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/DepartmentContainsKeywordsPredicate.java
@@ -5,6 +5,7 @@ import java.util.function.Predicate;
 
 import seedu.address.commons.util.StringUtil;
 
+//@@author Woonhian
 /**
  * Tests that a {@code Person}'s {@code Department} matches any of the keywords given.
  */

--- a/src/main/java/seedu/address/model/person/DepartmentContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/DepartmentContainsKeywordsPredicate.java
@@ -1,9 +1,9 @@
 package seedu.address.model.person;
 
-import seedu.address.commons.util.StringUtil;
-
 import java.util.List;
 import java.util.function.Predicate;
+
+import seedu.address.commons.util.StringUtil;
 
 /**
  * Tests that a {@code Person}'s {@code Department} matches any of the keywords given.

--- a/src/main/java/seedu/address/model/person/DepartmentContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/DepartmentContainsKeywordsPredicate.java
@@ -1,0 +1,31 @@
+package seedu.address.model.person;
+
+import seedu.address.commons.util.StringUtil;
+
+import java.util.List;
+import java.util.function.Predicate;
+
+/**
+ * Tests that a {@code Person}'s {@code Department} matches any of the keywords given.
+ */
+public class DepartmentContainsKeywordsPredicate implements Predicate<Person> {
+    private final List<String> keywords;
+
+    public DepartmentContainsKeywordsPredicate(List<String> keywords) {
+        this.keywords = keywords;
+    }
+
+    @Override
+    public boolean test(Person person) {
+        return keywords.stream()
+                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(person.getDepartment().fullDepartment, keyword));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof DepartmentContainsKeywordsPredicate // instanceof handles nulls
+                && keywords.equals(((DepartmentContainsKeywordsPredicate) other).keywords)); // state check
+    }
+
+}

--- a/src/main/java/seedu/address/model/person/UniquePersonList.java
+++ b/src/main/java/seedu/address/model/person/UniquePersonList.java
@@ -139,8 +139,8 @@ public class UniquePersonList implements Iterable<Person> {
             comparator = departmentComparator;
             break;
 
-            default:
-                throw new AssertionError("Invalid field parameter entered...\n");
+        default:
+            throw new AssertionError("Invalid field parameter entered...\n");
         }
 
         switch (order) {
@@ -152,8 +152,8 @@ public class UniquePersonList implements Iterable<Person> {
             Collections.sort(internalList, Collections.reverseOrder(comparator));
             break;
 
-            default:
-                throw new AssertionError("Invalid order parameter entered...\n");
+        default:
+            throw new AssertionError("Invalid order parameter entered...\n");
         }
     }
 

--- a/src/main/java/seedu/address/model/person/UniquePersonList.java
+++ b/src/main/java/seedu/address/model/person/UniquePersonList.java
@@ -115,16 +115,22 @@ public class UniquePersonList implements Iterable<Person> {
             throw new NoEmployeeException();
         }
 
-        Comparator<Person> comparator = null;
+        Comparator<Person> comparator;
 
-        Comparator<Person> nameComparator = new Comparator<Person>() {
+        /**
+         * Used to sort by name
+         */
+        class sortByName implements Comparator<Person>  {
             @Override
             public int compare(Person p1, Person p2) {
                 return p1.getName().fullName.compareTo(p2.getName().fullName);
             }
         };
 
-        Comparator<Person> departmentComparator = new Comparator<Person>() {
+        /**
+         * Used to sort by department
+         */
+        class sortByDepartment implements Comparator<Person> {
             @Override
             public int compare(Person p1, Person p2) {
                 return p1.getDepartment().fullDepartment.compareTo(p2.getDepartment().fullDepartment);
@@ -133,11 +139,11 @@ public class UniquePersonList implements Iterable<Person> {
 
         switch (field) {
         case "name":
-            comparator = nameComparator;
+            comparator = new sortByName();
             break;
 
         case "department":
-            comparator = departmentComparator;
+            comparator = new sortByDepartment();
             break;
 
         default:

--- a/src/main/java/seedu/address/model/person/UniquePersonList.java
+++ b/src/main/java/seedu/address/model/person/UniquePersonList.java
@@ -3,12 +3,15 @@ package seedu.address.model.person;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
 
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import seedu.address.model.person.exceptions.DuplicatePersonException;
+import seedu.address.model.person.exceptions.NoEmployeeException;
 import seedu.address.model.person.exceptions.PersonNotFoundException;
 
 /**
@@ -100,6 +103,58 @@ public class UniquePersonList implements Iterable<Person> {
      */
     public ObservableList<Person> asUnmodifiableObservableList() {
         return FXCollections.unmodifiableObservableList(internalList);
+    }
+
+    /**
+     * Sorts employees by name or department in ascending or descending order.
+     * @return
+     */
+    public void sortBy(String field, String order) throws NoEmployeeException {
+        if (internalList.size() < 1) {
+            throw new NoEmployeeException();
+        }
+
+        Comparator<Person> comparator = null;
+
+        Comparator<Person> nameComparator = new Comparator<Person>() {
+            @Override
+            public int compare(Person p1, Person p2) {
+                return p1.getName().fullName.compareTo(p2.getName().fullName);
+            }
+        };
+
+        Comparator<Person> departmentComparator = new Comparator<Person>() {
+            @Override
+            public int compare(Person p1, Person p2) {
+                return p1.getDepartment().fullDepartment.compareTo(p2.getDepartment().fullDepartment);
+            }
+        };
+
+        switch (field) {
+            case "name":
+                comparator = nameComparator;
+                break;
+
+            case "department":
+                comparator = departmentComparator;
+                break;
+
+            default:
+                throw new AssertionError("Invalid field parameter entered...\n");
+        }
+
+        switch (order) {
+            case "asc":
+                Collections.sort(internalList, comparator);
+                break;
+
+            case "desc":
+                Collections.sort(internalList, Collections.reverseOrder(comparator));
+                break;
+
+            default:
+                throw new AssertionError("Invalid order parameter entered...\n");
+        }
     }
 
     @Override

--- a/src/main/java/seedu/address/model/person/UniquePersonList.java
+++ b/src/main/java/seedu/address/model/person/UniquePersonList.java
@@ -131,26 +131,26 @@ public class UniquePersonList implements Iterable<Person> {
         };
 
         switch (field) {
-            case "name":
-                comparator = nameComparator;
-                break;
+        case "name":
+            comparator = nameComparator;
+            break;
 
-            case "department":
-                comparator = departmentComparator;
-                break;
+        case "department":
+            comparator = departmentComparator;
+            break;
 
             default:
                 throw new AssertionError("Invalid field parameter entered...\n");
         }
 
         switch (order) {
-            case "asc":
-                Collections.sort(internalList, comparator);
-                break;
+        case "asc":
+            Collections.sort(internalList, comparator);
+            break;
 
-            case "desc":
-                Collections.sort(internalList, Collections.reverseOrder(comparator));
-                break;
+        case "desc":
+            Collections.sort(internalList, Collections.reverseOrder(comparator));
+            break;
 
             default:
                 throw new AssertionError("Invalid order parameter entered...\n");

--- a/src/main/java/seedu/address/model/person/UniquePersonList.java
+++ b/src/main/java/seedu/address/model/person/UniquePersonList.java
@@ -120,7 +120,7 @@ public class UniquePersonList implements Iterable<Person> {
         /**
          * Used to sort by name
          */
-        class sortByName implements Comparator<Person>  {
+        Comparator<Person> nameComparator = new Comparator<Person>() {
             @Override
             public int compare(Person p1, Person p2) {
                 return p1.getName().fullName.compareTo(p2.getName().fullName);
@@ -130,7 +130,7 @@ public class UniquePersonList implements Iterable<Person> {
         /**
          * Used to sort by department
          */
-        class sortByDepartment implements Comparator<Person> {
+        Comparator<Person> departmentComparator = new Comparator<Person>() {
             @Override
             public int compare(Person p1, Person p2) {
                 return p1.getDepartment().fullDepartment.compareTo(p2.getDepartment().fullDepartment);
@@ -139,11 +139,11 @@ public class UniquePersonList implements Iterable<Person> {
 
         switch (field) {
         case "name":
-            comparator = new sortByName();
+            comparator = nameComparator;
             break;
 
         case "department":
-            comparator = new sortByDepartment();
+            comparator = departmentComparator;
             break;
 
         default:

--- a/src/main/java/seedu/address/model/person/UniquePersonList.java
+++ b/src/main/java/seedu/address/model/person/UniquePersonList.java
@@ -105,6 +105,7 @@ public class UniquePersonList implements Iterable<Person> {
         return FXCollections.unmodifiableObservableList(internalList);
     }
 
+    //@@author Woonhian
     /**
      * Sorts employees by name or department in ascending or descending order.
      * @return

--- a/src/main/java/seedu/address/model/person/exceptions/NoEmployeeException.java
+++ b/src/main/java/seedu/address/model/person/exceptions/NoEmployeeException.java
@@ -1,0 +1,7 @@
+package seedu.address.model.person.exceptions;
+
+/**
+ * Signals that the operation is unable to sort due to no employees in address book.
+ */
+public class NoEmployeeException extends Exception{
+}

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -136,6 +136,11 @@ public class AddCommandTest {
         }
 
         @Override
+        public void sortEmployee(String field, String order) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public void updatePerson(Person target, Person editedPerson) {
             throw new AssertionError("This method should not be called.");
         }

--- a/src/test/java/seedu/address/logic/commands/AddLeaveCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddLeaveCommandTest.java
@@ -133,6 +133,11 @@ public class AddLeaveCommandTest {
         }
 
         @Override
+        public void sortEmployee(String field, String order) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public void updatePerson(Person target, Person editedPerson) {
             throw new AssertionError("This method should not be called.");
         }

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -41,8 +41,8 @@ public class CommandTestUtil {
     public static final String VALID_PHONE_BOB = "22222222";
     public static final String VALID_EMAIL_AMY = "amy@example.com";
     public static final String VALID_EMAIL_BOB = "bob@example.com";
-    public static final String VALID_DEPARTMENT_AMY = "Junior Management";
-    public static final String VALID_DEPARTMENT_BOB = "Junior Management";
+    public static final String VALID_DEPARTMENT_AMY = "Top Management";
+    public static final String VALID_DEPARTMENT_BOB = "Top Management";
     public static final int VALID_PRIORITYLEVEL_AMY = PriorityLevelEnum.MANAGER.getPriorityLevelCode();
     public static final int VALID_PRIORITYLEVEL_BOB = PriorityLevelEnum.MANAGER.getPriorityLevelCode();
 

--- a/src/test/java/seedu/address/logic/commands/FilterDepartmentCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FilterDepartmentCommandTest.java
@@ -37,24 +37,24 @@ public class FilterDepartmentCommandTest {
         DepartmentContainsKeywordsPredicate secondPredicate =
                 new DepartmentContainsKeywordsPredicate(Collections.singletonList("second"));
 
-        FilterDepartmentCommand findFirstCommand = new FilterDepartmentCommand(firstPredicate);
-        FilterDepartmentCommand findSecondCommand = new FilterDepartmentCommand(secondPredicate);
+        FilterDepartmentCommand filterDepartmentFirstCommand = new FilterDepartmentCommand(firstPredicate);
+        FilterDepartmentCommand filterDepartmentSecondCommand = new FilterDepartmentCommand(secondPredicate);
 
         // same object -> returns true
-        assertTrue(findFirstCommand.equals(findFirstCommand));
+        assertTrue(filterDepartmentFirstCommand.equals(filterDepartmentFirstCommand));
 
         // same values -> returns true
-        FilterDepartmentCommand findFirstCommandCopy = new FilterDepartmentCommand(firstPredicate);
-        assertTrue(findFirstCommand.equals(findFirstCommandCopy));
+        FilterDepartmentCommand filterDepartmentFirstCommandCopy = new FilterDepartmentCommand(firstPredicate);
+        assertTrue(filterDepartmentFirstCommand.equals(filterDepartmentFirstCommandCopy));
 
         // different types -> returns false
-        assertFalse(findFirstCommand.equals(1));
+        assertFalse(filterDepartmentFirstCommand.equals(1));
 
         // null -> returns false
-        assertFalse(findFirstCommand.equals(null));
+        assertFalse(filterDepartmentFirstCommand.equals(null));
 
         // different department -> returns false
-        assertFalse(findFirstCommand.equals(findSecondCommand));
+        assertFalse(filterDepartmentFirstCommand.equals(filterDepartmentSecondCommand));
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/FilterDepartmentCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FilterDepartmentCommandTest.java
@@ -1,0 +1,85 @@
+package seedu.address.logic.commands;
+
+import org.junit.Test;
+import seedu.address.logic.CommandHistory;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.person.DepartmentContainsKeywordsPredicate;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static seedu.address.commons.core.Messages.MESSAGE_PERSONS_LISTED_OVERVIEW;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.testutil.TypicalPersons.CARL;
+import static seedu.address.testutil.TypicalPersons.ELLE;
+import static seedu.address.testutil.TypicalPersons.FIONA;
+import static seedu.address.testutil.TypicalPersons.GEORGE;
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+
+/**
+ * Contains integration tests (interaction with the Model) for {@code FindCommand}.
+ */
+public class FilterDepartmentCommandTest {
+    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+    private Model expectedModel = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+    private CommandHistory commandHistory = new CommandHistory();
+
+    @Test
+    public void equals() {
+        DepartmentContainsKeywordsPredicate firstPredicate =
+                new DepartmentContainsKeywordsPredicate(Collections.singletonList("first"));
+        DepartmentContainsKeywordsPredicate secondPredicate =
+                new DepartmentContainsKeywordsPredicate(Collections.singletonList("second"));
+
+        FilterDepartmentCommand findFirstCommand = new FilterDepartmentCommand(firstPredicate);
+        FilterDepartmentCommand findSecondCommand = new FilterDepartmentCommand(secondPredicate);
+
+        // same object -> returns true
+        assertTrue(findFirstCommand.equals(findFirstCommand));
+
+        // same values -> returns true
+        FilterDepartmentCommand findFirstCommandCopy = new FilterDepartmentCommand(firstPredicate);
+        assertTrue(findFirstCommand.equals(findFirstCommandCopy));
+
+        // different types -> returns false
+        assertFalse(findFirstCommand.equals(1));
+
+        // null -> returns false
+        assertFalse(findFirstCommand.equals(null));
+
+        // different department -> returns false
+        assertFalse(findFirstCommand.equals(findSecondCommand));
+    }
+
+    @Test
+    public void execute_zeroKeywords_noDepartmentFound() {
+        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 0);
+        DepartmentContainsKeywordsPredicate predicate = preparePredicate(" ");
+        FilterDepartmentCommand command = new FilterDepartmentCommand(predicate);
+        expectedModel.updateFilteredPersonList(predicate);
+        assertCommandSuccess(command, model, commandHistory, expectedMessage, expectedModel);
+        assertEquals(Collections.emptyList(), model.getFilteredPersonList());
+    }
+
+    @Test
+    public void execute_multipleKeywords_multipleDepartmentsFound() {
+        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 4);
+        DepartmentContainsKeywordsPredicate predicate = preparePredicate("Junior Senior");
+        FilterDepartmentCommand command = new FilterDepartmentCommand(predicate);
+        expectedModel.updateFilteredPersonList(predicate);
+        assertCommandSuccess(command, model, commandHistory, expectedMessage, expectedModel);
+        assertEquals(Arrays.asList(CARL, ELLE, FIONA, GEORGE), model.getFilteredPersonList());
+    }
+
+    /**
+     * Parses {@code userInput} into a {@code NameContainsKeywordsPredicate}.
+     */
+    private DepartmentContainsKeywordsPredicate preparePredicate(String userInput) {
+        return new DepartmentContainsKeywordsPredicate(Arrays.asList(userInput.split("\\s+")));
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/FilterDepartmentCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FilterDepartmentCommandTest.java
@@ -1,15 +1,5 @@
 package seedu.address.logic.commands;
 
-import org.junit.Test;
-import seedu.address.logic.CommandHistory;
-import seedu.address.model.Model;
-import seedu.address.model.ModelManager;
-import seedu.address.model.UserPrefs;
-import seedu.address.model.person.DepartmentContainsKeywordsPredicate;
-
-import java.util.Arrays;
-import java.util.Collections;
-
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -20,6 +10,17 @@ import static seedu.address.testutil.TypicalPersons.ELLE;
 import static seedu.address.testutil.TypicalPersons.FIONA;
 import static seedu.address.testutil.TypicalPersons.GEORGE;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import org.junit.Test;
+
+import seedu.address.logic.CommandHistory;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.person.DepartmentContainsKeywordsPredicate;
 
 /**
  * Contains integration tests (interaction with the Model) for {@code FindCommand}.

--- a/src/test/java/seedu/address/logic/commands/FilterDepartmentCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FilterDepartmentCommandTest.java
@@ -22,6 +22,7 @@ import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
 import seedu.address.model.person.DepartmentContainsKeywordsPredicate;
 
+//@@author Woonhian
 /**
  * Contains integration tests (interaction with the Model) for {@code FindCommand}.
  */

--- a/src/test/java/seedu/address/logic/commands/SortCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/SortCommandTest.java
@@ -47,6 +47,20 @@ public class SortCommandTest {
         assertCommandSuccess(command, model, commandHistory, expected, model);
     }
 
+    @Test
+    public void sortByDepartment_success() throws Exception {
+        SortCommand command = prepareCommand("department", "asc");
+        String expected = String.format(MESSAGE_SUCCESS, "department", "asc");
+        assertCommandSuccess(command, model, commandHistory, expected, model);
+    }
+
+    @Test
+    public void sortByDepartmentDesc_success() throws Exception {
+        SortCommand command = prepareCommand("department", "desc");
+        String expected = String.format(MESSAGE_SUCCESS, "department", "desc");
+        assertCommandSuccess(command, model, commandHistory, expected, model);
+    }
+
     /**
      * Returns a {@code sortCommand} with the parameters {@code field and @code order}.
      */

--- a/src/test/java/seedu/address/logic/commands/SortCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/SortCommandTest.java
@@ -1,7 +1,9 @@
 package seedu.address.logic.commands;
 
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.logic.commands.SortCommand.MESSAGE_SUCCESS;
+import static seedu.address.testutil.TypicalPersons.getEmptyAddressBook;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
 import org.junit.Rule;
@@ -19,7 +21,14 @@ public class SortCommandTest {
     public ExpectedException error = ExpectedException.none();
 
     private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+    private Model emptyModel = new ModelManager(getEmptyAddressBook(), new UserPrefs());
     private CommandHistory commandHistory = new CommandHistory();
+
+    @Test
+    public void noEmployees() {
+        SortCommand command = prepareCommand("name", "asc");
+        assertCommandFailure(command, emptyModel, commandHistory, SortCommand.MESSAGE_EMPTY_BOOK);
+    }
 
     @Test
     public void emptySortField_throwsNullPointerEx() {
@@ -34,28 +43,28 @@ public class SortCommandTest {
     }
 
     @Test
-    public void sortByName_success() throws Exception {
+    public void sortByName_success() {
         SortCommand command = prepareCommand("name", "asc");
         String expected = String.format(MESSAGE_SUCCESS, "name", "asc");
         assertCommandSuccess(command, model, commandHistory, expected, model);
     }
 
     @Test
-    public void sortByNameDesc_success() throws Exception {
+    public void sortByNameDesc_success() {
         SortCommand command = prepareCommand("name", "desc");
         String expected = String.format(MESSAGE_SUCCESS, "name", "desc");
         assertCommandSuccess(command, model, commandHistory, expected, model);
     }
 
     @Test
-    public void sortByDepartment_success() throws Exception {
+    public void sortByDepartment_success() {
         SortCommand command = prepareCommand("department", "asc");
         String expected = String.format(MESSAGE_SUCCESS, "department", "asc");
         assertCommandSuccess(command, model, commandHistory, expected, model);
     }
 
     @Test
-    public void sortByDepartmentDesc_success() throws Exception {
+    public void sortByDepartmentDesc_success() {
         SortCommand command = prepareCommand("department", "desc");
         String expected = String.format(MESSAGE_SUCCESS, "department", "desc");
         assertCommandSuccess(command, model, commandHistory, expected, model);

--- a/src/test/java/seedu/address/logic/commands/SortCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/SortCommandTest.java
@@ -8,9 +8,12 @@ import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
 import org.junit.rules.ExpectedException;
 
+import seedu.address.commons.core.Messages;
 import seedu.address.logic.CommandHistory;
+import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
@@ -40,6 +43,20 @@ public class SortCommandTest {
     public void emptySortOrder_throwsNullPointerEx() {
         error.expect(NullPointerException.class);
         new SortCommand(null, "asc");
+    }
+
+    @Test
+    public void execute_wrongField_throwsAssertionError() {
+        Assertions.assertThrows(AssertionError.class, () -> {
+            new SortCommand("invalid","asc").execute(model, commandHistory);
+        }, Messages.MESSAGE_INVALID_COMMAND_FORMAT);
+    }
+
+    @Test
+    public void execute_wrongOrder_throwsAssertionError() {
+        Assertions.assertThrows(AssertionError.class, () -> {
+            new SortCommand("name","invalid").execute(model, commandHistory);
+        }, Messages.MESSAGE_INVALID_COMMAND_FORMAT);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/SortCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/SortCommandTest.java
@@ -47,14 +47,14 @@ public class SortCommandTest {
     @Test
     public void execute_wrongField_throwsAssertionError() {
         Assertions.assertThrows(AssertionError.class, () -> {
-            new SortCommand("invalid","asc").execute(model, commandHistory);
+            new SortCommand("invalid", "asc").execute(model, commandHistory);
         }, Messages.MESSAGE_INVALID_COMMAND_FORMAT);
     }
 
     @Test
     public void execute_wrongOrder_throwsAssertionError() {
         Assertions.assertThrows(AssertionError.class, () -> {
-            new SortCommand("name","invalid").execute(model, commandHistory);
+            new SortCommand("name", "invalid").execute(model, commandHistory);
         }, Messages.MESSAGE_INVALID_COMMAND_FORMAT);
     }
 

--- a/src/test/java/seedu/address/logic/commands/SortCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/SortCommandTest.java
@@ -17,6 +17,7 @@ import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
 
+//@@author Woonhian
 public class SortCommandTest {
 
     @Rule

--- a/src/test/java/seedu/address/logic/commands/SortCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/SortCommandTest.java
@@ -35,9 +35,16 @@ public class SortCommandTest {
 
     @Test
     public void sortByName_success() throws Exception {
-        SortCommand so = prepareCommand("name", "asc");
+        SortCommand command = prepareCommand("name", "asc");
         String expected = String.format(MESSAGE_SUCCESS, "name", "asc");
-        assertCommandSuccess(so, model, commandHistory, expected, model);
+        assertCommandSuccess(command, model, commandHistory, expected, model);
+    }
+
+    @Test
+    public void sortByNameDesc_success() throws Exception {
+        SortCommand command = prepareCommand("name", "desc");
+        String expected = String.format(MESSAGE_SUCCESS, "name", "desc");
+        assertCommandSuccess(command, model, commandHistory, expected, model);
     }
 
     /**

--- a/src/test/java/seedu/address/logic/commands/SortCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/SortCommandTest.java
@@ -1,0 +1,50 @@
+package seedu.address.logic.commands;
+
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.logic.commands.SortCommand.MESSAGE_SUCCESS;
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import seedu.address.logic.CommandHistory;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+
+public class SortCommandTest {
+
+    @Rule
+    public ExpectedException error = ExpectedException.none();
+
+    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+    private CommandHistory commandHistory = new CommandHistory();
+
+    @Test
+    public void emptySortField_throwsNullPointerEx() {
+        error.expect(NullPointerException.class);
+        new SortCommand("name", null);
+    }
+
+    @Test
+    public void emptySortOrder_throwsNullPointerEx() {
+        error.expect(NullPointerException.class);
+        new SortCommand(null, "asc");
+    }
+
+    @Test
+    public void sortByName_success() throws Exception {
+        SortCommand so = prepareCommand("name", "asc");
+        String expected = String.format(MESSAGE_SUCCESS, "name", "asc");
+        assertCommandSuccess(so, model, commandHistory, expected, model);
+    }
+
+    /**
+     * Returns a {@code sortCommand} with the parameters {@code field and @code order}.
+     */
+    private SortCommand prepareCommand(String field, String order) {
+        SortCommand sortCommand = new SortCommand(field, order);
+        return sortCommand;
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/SortCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/SortCommandTest.java
@@ -13,7 +13,6 @@ import org.junit.rules.ExpectedException;
 
 import seedu.address.commons.core.Messages;
 import seedu.address.logic.CommandHistory;
-import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -21,14 +21,17 @@ import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.EditCommand.EditPersonDescriptor;
 import seedu.address.logic.commands.ExitCommand;
+import seedu.address.logic.commands.FilterDepartmentCommand;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.HistoryCommand;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.commands.RedoCommand;
 import seedu.address.logic.commands.SelectCommand;
+import seedu.address.logic.commands.SortCommand;
 import seedu.address.logic.commands.UndoCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.person.DepartmentContainsKeywordsPredicate;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
 import seedu.address.model.person.Person;
 import seedu.address.testutil.EditPersonDescriptorBuilder;
@@ -85,6 +88,15 @@ public class AddressBookParserTest {
     }
 
     @Test
+    public void parseCommand_filterdepartment() throws Exception {
+        List<String> keywords = Arrays.asList("junior", "senior");
+        FilterDepartmentCommand command = (FilterDepartmentCommand) parser.parseCommand(
+                FilterDepartmentCommand.COMMAND_WORD + " " + keywords.stream()
+                        .collect(Collectors.joining(" ")));
+        assertEquals(new FilterDepartmentCommand(new DepartmentContainsKeywordsPredicate(keywords)), command);
+    }
+
+    @Test
     public void parseCommand_help() throws Exception {
         assertTrue(parser.parseCommand(HelpCommand.COMMAND_WORD) instanceof HelpCommand);
         assertTrue(parser.parseCommand(HelpCommand.COMMAND_WORD + " 3") instanceof HelpCommand);
@@ -114,6 +126,13 @@ public class AddressBookParserTest {
         SelectCommand command = (SelectCommand) parser.parseCommand(
                 SelectCommand.COMMAND_WORD + " " + INDEX_FIRST_PERSON.getOneBased());
         assertEquals(new SelectCommand(INDEX_FIRST_PERSON), command);
+    }
+
+    @Test
+    public void parseCommand_sort() throws Exception {
+        assertTrue(parser.parseCommand(SortCommand.COMMAND_WORD + " "
+                + SortCommandParser.ACCEPTED_FIELDS.get(0) + " "
+                + SortCommandParser.ACCEPTED_ORDERS.get(0)) instanceof SortCommand);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/FilterDepartmentCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FilterDepartmentCommandParserTest.java
@@ -1,0 +1,35 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+
+import java.util.Arrays;
+
+import org.junit.Test;
+
+import seedu.address.logic.commands.FilterDepartmentCommand;
+import seedu.address.model.person.DepartmentContainsKeywordsPredicate;
+
+public class FilterDepartmentCommandParserTest {
+
+    private FilterDepartmentCommandParser parser = new FilterDepartmentCommandParser();
+
+    @Test
+    public void parse_emptyArg_throwsParseException() {
+        assertParseFailure(parser, "     ", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                FilterDepartmentCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_validArgs_returnsFilterDepartmentCommand() {
+        // no leading and trailing whitespaces
+        FilterDepartmentCommand expectedFilterDepartmentCommand =
+                new FilterDepartmentCommand(new DepartmentContainsKeywordsPredicate(Arrays.asList("junior", "senior")));
+        assertParseSuccess(parser, "junior senior", expectedFilterDepartmentCommand);
+
+        // multiple whitespaces between keywords
+        assertParseSuccess(parser, " \n junior \n \t senior  \t", expectedFilterDepartmentCommand);
+    }
+
+}

--- a/src/test/java/seedu/address/logic/parser/FilterDepartmentCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FilterDepartmentCommandParserTest.java
@@ -11,6 +11,7 @@ import org.junit.Test;
 import seedu.address.logic.commands.FilterDepartmentCommand;
 import seedu.address.model.person.DepartmentContainsKeywordsPredicate;
 
+//@@author Woonhian
 public class FilterDepartmentCommandParserTest {
 
     private FilterDepartmentCommandParser parser = new FilterDepartmentCommandParser();

--- a/src/test/java/seedu/address/logic/parser/SortCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/SortCommandParserTest.java
@@ -22,7 +22,7 @@ public class SortCommandParserTest {
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, MESSAGE_USAGE));
 
         //invalid field entered
-        assertParseFailure(parser, "invalid" + "asc",
+        assertParseFailure(parser, "invalid" + " " + "asc",
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, MESSAGE_USAGE));
 
         //invalid sort order entered
@@ -30,7 +30,7 @@ public class SortCommandParserTest {
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, MESSAGE_USAGE));
 
         //no field entered
-        assertParseFailure(parser, "",
+        assertParseFailure(parser, "asc",
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, MESSAGE_USAGE));
 
         //no order entered

--- a/src/test/java/seedu/address/logic/parser/SortCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/SortCommandParserTest.java
@@ -31,8 +31,8 @@ public class SortCommandParserTest {
 
         //no field entered
         assertParseFailure(parser, "asc",
-                String.format(MESSAGE_INVALID_COMMAND_FORMAT, MESSAGE_USAGE))
-        ;
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, MESSAGE_USAGE));
+        
         //no order entered
         assertParseFailure(parser, "name",
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, MESSAGE_USAGE));

--- a/src/test/java/seedu/address/logic/parser/SortCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/SortCommandParserTest.java
@@ -30,7 +30,7 @@ public class SortCommandParserTest {
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, MESSAGE_USAGE));
 
         //no field entered
-        assertParseFailure(parser, "asc",
+        assertParseFailure(parser, " " + " " + "asc",
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, MESSAGE_USAGE));
 
         //no order entered

--- a/src/test/java/seedu/address/logic/parser/SortCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/SortCommandParserTest.java
@@ -1,0 +1,40 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.commands.SortCommand.MESSAGE_USAGE;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+
+import org.junit.Test;
+
+public class SortCommandParserTest {
+
+    private SortCommandParser parser = new SortCommandParser();
+
+    @Test
+    public void parse_emptyArg_throwsParseException() {
+        assertParseFailure(parser, "     ", String.format(MESSAGE_INVALID_COMMAND_FORMAT, MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_invalidArguments_failure() {
+        //more than 1 field entered
+        assertParseFailure(parser, "name" + " " + "department" + " " + "asc",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, MESSAGE_USAGE));
+
+        //invalid field entered
+        assertParseFailure(parser, "invalid" + "asc",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, MESSAGE_USAGE));
+
+        //invalid sort order entered
+        assertParseFailure(parser, "name" + " " + "invalid",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, MESSAGE_USAGE));
+
+        //no field entered
+        assertParseFailure(parser, "asc",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, MESSAGE_USAGE))
+        ;
+        //no order entered
+        assertParseFailure(parser, "name",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, MESSAGE_USAGE));
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/SortCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/SortCommandParserTest.java
@@ -32,7 +32,7 @@ public class SortCommandParserTest {
         //no field entered
         assertParseFailure(parser, "asc",
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, MESSAGE_USAGE));
-        
+
         //no order entered
         assertParseFailure(parser, "name",
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, MESSAGE_USAGE));

--- a/src/test/java/seedu/address/logic/parser/SortCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/SortCommandParserTest.java
@@ -30,7 +30,7 @@ public class SortCommandParserTest {
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, MESSAGE_USAGE));
 
         //no field entered
-        assertParseFailure(parser, " " + " " + "asc",
+        assertParseFailure(parser, "",
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, MESSAGE_USAGE));
 
         //no order entered

--- a/src/test/java/seedu/address/logic/parser/SortCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/SortCommandParserTest.java
@@ -6,6 +6,7 @@ import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailur
 
 import org.junit.Test;
 
+//@@author Woonhian
 public class SortCommandParserTest {
 
     private SortCommandParser parser = new SortCommandParser();

--- a/src/test/java/seedu/address/model/person/DepartmentTest.java
+++ b/src/test/java/seedu/address/model/person/DepartmentTest.java
@@ -30,12 +30,12 @@ public class DepartmentTest {
         assertFalse(Department.isValidDepartment(" ")); // spaces only
         assertFalse(Department.isValidDepartment("^")); // only non-alphanumeric characters
         assertFalse(Department.isValidDepartment("junior*")); // contains non-alphanumeric characters
+        assertFalse(Department.isValidDepartment("Junior")); // does not end with Management
+        assertFalse(Department.isValidDepartment("Jun1or Management")); // contains alphanumeric characters
 
         // valid department name
-        assertTrue(Department.isValidDepartment("junior management")); // alphabets only
-        assertTrue(Department.isValidDepartment("12345")); // numbers only
-        assertTrue(Department.isValidDepartment("1st junior")); // alphanumeric characters
+        assertTrue(Department.isValidDepartment("junior Management")); // alphabets only
         assertTrue(Department.isValidDepartment("Junior Management")); // with capital letters
-        assertTrue(Department.isValidDepartment("2nd Junior Management")); // long names
+        assertTrue(Department.isValidDepartment("First Junior Management")); // long names
     }
 }

--- a/src/test/java/seedu/address/model/person/DepartmentTest.java
+++ b/src/test/java/seedu/address/model/person/DepartmentTest.java
@@ -32,7 +32,6 @@ public class DepartmentTest {
         assertFalse(Department.isValidDepartment("junior*")); // contains non-alphanumeric characters
         assertFalse(Department.isValidDepartment("Junior")); // does not end with Management
         assertFalse(Department.isValidDepartment("Jun1or Management")); // contains alphanumeric characters
-        assertFalse(Department.isValidDepartment("Management Management")); // contains 2 Management
 
         // valid department name
         assertTrue(Department.isValidDepartment("junior Management")); // alphabets only

--- a/src/test/java/seedu/address/model/person/DepartmentTest.java
+++ b/src/test/java/seedu/address/model/person/DepartmentTest.java
@@ -7,6 +7,7 @@ import org.junit.Test;
 
 import seedu.address.testutil.Assert;
 
+//@@author Woonhian
 public class DepartmentTest {
 
     @Test

--- a/src/test/java/seedu/address/model/person/DepartmentTest.java
+++ b/src/test/java/seedu/address/model/person/DepartmentTest.java
@@ -32,6 +32,7 @@ public class DepartmentTest {
         assertFalse(Department.isValidDepartment("junior*")); // contains non-alphanumeric characters
         assertFalse(Department.isValidDepartment("Junior")); // does not end with Management
         assertFalse(Department.isValidDepartment("Jun1or Management")); // contains alphanumeric characters
+        assertFalse(Department.isValidDepartment("Management Management")); // contains 2 Management
 
         // valid department name
         assertTrue(Department.isValidDepartment("junior Management")); // alphabets only

--- a/src/test/java/seedu/address/storage/XmlAdaptedPersonTest.java
+++ b/src/test/java/seedu/address/storage/XmlAdaptedPersonTest.java
@@ -133,6 +133,7 @@ public class XmlAdaptedPersonTest {
         Assert.assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
 
+    //@@author Woonhian
     @Test
     public void toModelType_invalidDepartment_throwsIllegalValueException() {
         XmlAdaptedPerson person =
@@ -142,6 +143,7 @@ public class XmlAdaptedPersonTest {
         Assert.assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
 
+    //@@author Woonhian
     @Test
     public void toModelType_nullDepartment_throwsIllegalValueException() {
         XmlAdaptedPerson person = new XmlAdaptedPerson(VALID_NAME, VALID_NRIC, VALID_PASSWORD, VALID_PHONE,

--- a/src/test/java/seedu/address/testutil/TypicalPersons.java
+++ b/src/test/java/seedu/address/testutil/TypicalPersons.java
@@ -2,6 +2,8 @@ package seedu.address.testutil;
 
 import static seedu.address.logic.commands.CommandTestUtil.VALID_ADDRESS_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_ADDRESS_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_DEPARTMENT_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_DEPARTMENT_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_EMAIL_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_EMAIL_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_AMY;
@@ -30,44 +32,52 @@ public class TypicalPersons {
     public static final Person ALICE = new PersonBuilder().withName("Alice Pauline")
             .withNric("T2457888E").withPassword("ASd654")
             .withAddress("123, Jurong West Ave 6, #08-111").withEmail("alice@example.com")
-            .withPhone("94351253")
+            .withDepartment("Top Management").withPhone("94351253")
             .withTags("friends").build();
     public static final Person BENSON = new PersonBuilder().withName("Benson Meier")
             .withNric("T2457846E").withPassword("ASd654")
             .withAddress("311, Clementi Ave 2, #02-25")
-            .withEmail("johnd@example.com").withPhone("98765432")
+            .withEmail("johnd@example.com").withDepartment("Top Management").withPhone("98765432")
             .withTags("owesMoney", "friends").build();
     public static final Person CARL = new PersonBuilder().withName("Carl Kurz").withPhone("95352563")
             .withNric("T2456699E").withPassword("ASd654")
-            .withEmail("heinz@example.com").withAddress("wall street").build();
+            .withEmail("heinz@example.com").withDepartment("Senior Management").withAddress("wall street").build();
     public static final Person DANIEL = new PersonBuilder().withName("Daniel Meier").withPhone("87652533")
             .withNric("S2457855E").withPassword("ASd654")
-            .withEmail("cornelia@example.com").withAddress("10th street").withTags("friends").build();
+            .withEmail("cornelia@example.com").withDepartment("Middle Management")
+            .withAddress("10th street").withTags("friends").build();
     public static final Person ELLE = new PersonBuilder().withName("Elle Meyer").withPhone("9482224")
             .withNric("T0257855E").withPassword("ASd654")
-            .withEmail("werner@example.com").withAddress("michegan ave").build();
+            .withEmail("werner@example.com").withDepartment("Junior Management")
+            .withAddress("michegan ave").build();
     public static final Person FIONA = new PersonBuilder().withName("Fiona Kunz").withPhone("9482427")
             .withNric("T2457005E").withPassword("ASd654")
-            .withEmail("lydia@example.com").withAddress("little tokyo").build();
+            .withEmail("lydia@example.com").withDepartment("Junior Management")
+            .withAddress("little tokyo").build();
     public static final Person GEORGE = new PersonBuilder().withName("George Best").withPhone("9482442")
             .withNric("T2457775E").withPassword("ASd654")
-            .withEmail("anna@example.com").withAddress("4th street").build();
+            .withEmail("anna@example.com").withDepartment("Junior Management")
+            .withAddress("4th street").build();
 
     // Manually added
     public static final Person HOON = new PersonBuilder().withName("Hoon Meier").withPhone("8482424")
             .withNric("T2457465H").withPassword("ASd654")
-            .withEmail("stefan@example.com").withAddress("little india").build();
+            .withEmail("stefan@example.com").withDepartment("Junior Management")
+            .withAddress("little india").build();
     public static final Person IDA = new PersonBuilder().withName("Ida Mueller").withPhone("8482131")
             .withNric("T1234567E").withPassword("ASd654")
-            .withEmail("hans@example.com").withAddress("chicago ave").build();
+            .withEmail("hans@example.com").withDepartment("Junior Management")
+            .withAddress("chicago ave").build();
 
     // Manually added - Person's details found in {@code CommandTestUtil}
     public static final Person AMY = new PersonBuilder().withName(VALID_NAME_AMY).withNric(VALID_NRIC_AMY)
             .withPassword(VALID_PASSWORD_AMY).withPhone(VALID_PHONE_AMY)
-            .withEmail(VALID_EMAIL_AMY).withAddress(VALID_ADDRESS_AMY).withTags(VALID_TAG_FRIEND).build();
+            .withEmail(VALID_EMAIL_AMY).withDepartment(VALID_DEPARTMENT_AMY)
+            .withAddress(VALID_ADDRESS_AMY).withTags(VALID_TAG_FRIEND).build();
     public static final Person BOB = new PersonBuilder().withName(VALID_NAME_BOB).withPhone(VALID_PHONE_BOB)
             .withNric(VALID_NRIC_BOB).withPassword(VALID_PASSWORD_BOB)
-            .withEmail(VALID_EMAIL_BOB).withAddress(VALID_ADDRESS_BOB).withTags(VALID_TAG_HUSBAND, VALID_TAG_FRIEND)
+            .withEmail(VALID_EMAIL_BOB).withDepartment(VALID_DEPARTMENT_BOB)
+            .withAddress(VALID_ADDRESS_BOB).withTags(VALID_TAG_HUSBAND, VALID_TAG_FRIEND)
             .build();
 
     public static final String KEYWORD_MATCHING_MEIER = "Meier"; // A keyword that matches MEIER

--- a/src/test/java/seedu/address/testutil/TypicalPersons.java
+++ b/src/test/java/seedu/address/testutil/TypicalPersons.java
@@ -87,6 +87,14 @@ public class TypicalPersons {
     /**
      * Returns an {@code AddressBook} with all the typical persons.
      */
+    public static AddressBook getEmptyAddressBook() {
+        AddressBook ab = new AddressBook();
+        return ab;
+    }
+
+    /**
+     * Returns an {@code AddressBook} with all the typical persons.
+     */
     public static AddressBook getTypicalAddressBook() {
         AddressBook ab = new AddressBook();
         for (Person person : getTypicalPersons()) {

--- a/src/test/java/seedu/address/ui/PersonListPanelTest.java
+++ b/src/test/java/seedu/address/ui/PersonListPanelTest.java
@@ -100,7 +100,7 @@ public class PersonListPanelTest extends GuiUnitTest {
             builder.append("<password>Asd123</password>\n");
             builder.append("<phone>000</phone>\n");
             builder.append("<email>a@aa</email>\n");
-            builder.append("<department>d</department>\n");
+            builder.append("<department>Junior Management</department>\n");
             builder.append("<address>a</address>\n");
             builder.append("</persons>\n");
         }


### PR DESCRIPTION
**v1.2**

### SortCommand
- Added `sort` command
- Able to sort employees based on their name or sort by departments in ascending or descending order

### FilterDepartmentCommand
- Added `filterdepartment` command
- Alias: `fd`
- Able to filter out departments to view certain department employee list
- The word 'Management' will not be able to filter departments to prevent the command from showing all of the departments as all departments have the word 'Management'

#### Enhancements
- Changed department fields naming to be strict such that naming of a department needs to be a alphabetic name, followed by 'Management'. e.g. Junior Management

**Test cases added for SortCommand and FilterDepartmentCommand**

Resolves #37 
Resolves #39 