### PR TITLE
V1.2: Establish priority level restrictions

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -74,7 +74,7 @@ public class AddCommand extends Command {
         /**
          * Throws exception if user does not have the required access level.
          */
-        if (!SessionManager.hasSufficientPriorityLevelForThisSession(model, PriorityLevelEnum.ADMINISTRATOR)) {
+        if (!SessionManager.hasSufficientPriorityLevelForThisSession(PriorityLevelEnum.ADMINISTRATOR)) {
             throw new CommandException(String.format(PriorityLevel.INSUFFICIENT_PRIORITY_LEVEL,
                     PriorityLevelEnum.ADMINISTRATOR));
         }

--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -8,6 +8,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NRIC;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PASSWORD;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PRIORITYLEVEL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
 import seedu.address.logic.CommandHistory;
@@ -31,6 +32,7 @@ public class AddCommand extends Command {
             + PREFIX_EMAIL + "EMAIL "
             + PREFIX_DEPARTMENT + "DEPARTMENT "
             + PREFIX_ADDRESS + "ADDRESS "
+            + "[" + PREFIX_PRIORITYLEVEL + "PRIORITYLEVEL]"
             + "[" + PREFIX_TAG + "TAG]...\n"
             + "Example: " + COMMAND_WORD + " "
             + PREFIX_NAME + "John Doe "

--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -14,7 +14,10 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 import seedu.address.logic.CommandHistory;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
+import seedu.address.model.SessionManager;
 import seedu.address.model.person.Person;
+import seedu.address.model.prioritylevel.PriorityLevel;
+import seedu.address.model.prioritylevel.PriorityLevelEnum;
 
 /**
  * Adds a person to the address book.
@@ -58,9 +61,23 @@ public class AddCommand extends Command {
         toAdd = person;
     }
 
+    /**
+     * AddCommand() requires user of admin rights to be logged in.
+     */
     @Override
     public CommandResult execute(Model model, CommandHistory history) throws CommandException {
         requireNonNull(model);
+
+        if (!SessionManager.isLoggedIn()) {
+            throw new CommandException(SessionManager.NOT_LOGGED_IN);
+        }
+        /**
+         * Throws exception if user does not have the required access level.
+         */
+        if (!SessionManager.hasSufficientPriorityLevelForThisSession(model, PriorityLevelEnum.ADMINISTRATOR)) {
+            throw new CommandException(String.format(PriorityLevel.INSUFFICIENT_PRIORITY_LEVEL,
+                    PriorityLevelEnum.ADMINISTRATOR));
+        }
 
         if (model.hasPerson(toAdd)) {
             throw new CommandException(MESSAGE_DUPLICATE_PERSON);

--- a/src/main/java/seedu/address/logic/commands/CheckLoginStatusCommand.java
+++ b/src/main/java/seedu/address/logic/commands/CheckLoginStatusCommand.java
@@ -1,6 +1,7 @@
 package seedu.address.logic.commands;
 
 import seedu.address.logic.CommandHistory;
+import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.SessionManager;
 
@@ -14,11 +15,12 @@ public class CheckLoginStatusCommand extends Command {
     public static final String STATUS_NOT_LOGGED_IN = "You are not logged in.";
 
     @Override
-    public CommandResult execute(Model model, CommandHistory history) {
+    public CommandResult execute(Model model, CommandHistory history) throws CommandException {
         if (!SessionManager.isLoggedIn()) {
             return new CommandResult(STATUS_NOT_LOGGED_IN);
         } else {
-            return new CommandResult(String.format(STATUS_LOGGED_IN, SessionManager.getLoggedInSessionNric()));
+            return new CommandResult(String.format(STATUS_LOGGED_IN,
+                    SessionManager.getLoggedInSessionNric()));
         }
     }
 }

--- a/src/main/java/seedu/address/logic/commands/CheckLoginStatusCommand.java
+++ b/src/main/java/seedu/address/logic/commands/CheckLoginStatusCommand.java
@@ -5,6 +5,7 @@ import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.SessionManager;
 
+//@@author jylee-git
 /**
  * Returns the log in status to the user.
  * Also returns the current logged in NRIC if the app's logged in.

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -9,7 +9,10 @@ import seedu.address.commons.core.index.Index;
 import seedu.address.logic.CommandHistory;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
+import seedu.address.model.SessionManager;
 import seedu.address.model.person.Person;
+import seedu.address.model.prioritylevel.PriorityLevel;
+import seedu.address.model.prioritylevel.PriorityLevelEnum;
 
 /**
  * Deletes a person identified using it's displayed index from the address book.
@@ -25,6 +28,8 @@ public class DeleteCommand extends Command {
 
     public static final String MESSAGE_DELETE_PERSON_SUCCESS = "Deleted Person: %1$s";
 
+    private static final String MESSAGE_CANNOT_DELETE_YOURSELF = "You can't delete yourself!";
+
     private final Index targetIndex;
 
     public DeleteCommand(Index targetIndex) {
@@ -34,6 +39,20 @@ public class DeleteCommand extends Command {
     @Override
     public CommandResult execute(Model model, CommandHistory history) throws CommandException {
         requireNonNull(model);
+        /**
+         * Throws exception if user is not logged in.
+         */
+        if (!SessionManager.isLoggedIn()) {
+            throw new CommandException(SessionManager.NOT_LOGGED_IN);
+        }
+        /**
+         * Throws exception if user does not have the required access level.
+         */
+        if (!SessionManager.hasSufficientPriorityLevelForThisSession(model, PriorityLevelEnum.ADMINISTRATOR)) {
+            throw new CommandException(String.format(PriorityLevel.INSUFFICIENT_PRIORITY_LEVEL,
+                    PriorityLevelEnum.ADMINISTRATOR));
+        }
+
         List<Person> lastShownList = model.getFilteredPersonList();
 
         if (targetIndex.getZeroBased() >= lastShownList.size()) {
@@ -41,6 +60,11 @@ public class DeleteCommand extends Command {
         }
 
         Person personToDelete = lastShownList.get(targetIndex.getZeroBased());
+
+        if (personToDelete == SessionManager.getLoggedInPersonDetails(model)) {
+            throw new CommandException(MESSAGE_CANNOT_DELETE_YOURSELF);
+        }
+
         model.deletePerson(personToDelete);
         model.commitAddressBook();
         return new CommandResult(String.format(MESSAGE_DELETE_PERSON_SUCCESS, personToDelete));

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -48,7 +48,7 @@ public class DeleteCommand extends Command {
         /**
          * Throws exception if user does not have the required access level.
          */
-        if (!SessionManager.hasSufficientPriorityLevelForThisSession(model, PriorityLevelEnum.ADMINISTRATOR)) {
+        if (!SessionManager.hasSufficientPriorityLevelForThisSession(PriorityLevelEnum.ADMINISTRATOR)) {
             throw new CommandException(String.format(PriorityLevel.INSUFFICIENT_PRIORITY_LEVEL,
                     PriorityLevelEnum.ADMINISTRATOR));
         }

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -105,7 +105,7 @@ public class EditCommand extends Command {
 
         return new Person(updatedName, personToEdit.getNric(),
                 personToEdit.getPassword(), updatedPhone, updatedEmail, updatedDepartment,
-                          updatedAddress, updatedTags);
+                personToEdit.getPriorityLevel(), updatedAddress, updatedTags);
     }
 
     @Override
@@ -148,7 +148,6 @@ public class EditCommand extends Command {
          */
         public EditPersonDescriptor(EditPersonDescriptor toCopy) {
             setName(toCopy.name);
-
             setPhone(toCopy.phone);
             setEmail(toCopy.email);
             setDepartment(toCopy.department);
@@ -247,6 +246,7 @@ public class EditCommand extends Command {
                     && getPhone().equals(e.getPhone())
                     && getEmail().equals(e.getEmail())
                     && getDepartment().equals(e.getDepartment())
+
                     && getAddress().equals(e.getAddress())
                     && getTags().equals(e.getTags());
         }

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -21,6 +21,7 @@ import seedu.address.commons.util.CollectionUtil;
 import seedu.address.logic.CommandHistory;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
+import seedu.address.model.SessionManager;
 import seedu.address.model.person.Address;
 import seedu.address.model.person.Department;
 import seedu.address.model.person.Email;
@@ -74,6 +75,10 @@ public class EditCommand extends Command {
     @Override
     public CommandResult execute(Model model, CommandHistory history) throws CommandException {
         requireNonNull(model);
+        if (!SessionManager.isLoggedIn()) {
+            throw new CommandException(SessionManager.NOT_LOGGED_IN);
+        }
+
         List<Person> lastShownList = model.getFilteredPersonList();
 
         if (index.getZeroBased() >= lastShownList.size()) {
@@ -170,13 +175,13 @@ public class EditCommand extends Command {
             return Optional.ofNullable(name);
         }
 
-        public void setNric(Nric nric) {
+        /*public void setNric(Nric nric) {
             this.nric = nric;
         }
 
         public void setPassword(Password password) {
             this.password = password;
-        }
+        }*/
 
         public void setPhone(Phone phone) {
             this.phone = phone;

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -30,6 +30,7 @@ import seedu.address.model.person.Nric;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
 import seedu.address.model.person.password.Password;
+import seedu.address.model.prioritylevel.PriorityLevel;
 import seedu.address.model.tag.Tag;
 
 /**
@@ -142,6 +143,7 @@ public class EditCommand extends Command {
         private Phone phone;
         private Email email;
         private Department department;
+        private PriorityLevel priorityLevel;
         private Address address;
         private Set<Tag> tags;
 
@@ -175,13 +177,13 @@ public class EditCommand extends Command {
             return Optional.ofNullable(name);
         }
 
-        /*public void setNric(Nric nric) {
+        public void setNric(Nric nric) {
             this.nric = nric;
         }
 
         public void setPassword(Password password) {
             this.password = password;
-        }*/
+        }
 
         public void setPhone(Phone phone) {
             this.phone = phone;
@@ -205,6 +207,10 @@ public class EditCommand extends Command {
 
         public Optional<Department> getDepartment() {
             return Optional.ofNullable(department);
+        }
+
+        public void setPriorityLevel(PriorityLevel priorityLevel) {
+            this.priorityLevel = priorityLevel;
         }
 
         public void setAddress(Address address) {

--- a/src/main/java/seedu/address/logic/commands/LoginCommand.java
+++ b/src/main/java/seedu/address/logic/commands/LoginCommand.java
@@ -15,6 +15,7 @@ import seedu.address.model.person.Nric;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.password.Password;
 
+//@@author jylee-git
 /**
  * Enables the use of application by logging in using the specified personnel's NRIC and password.
  */

--- a/src/main/java/seedu/address/logic/commands/LoginCommand.java
+++ b/src/main/java/seedu/address/logic/commands/LoginCommand.java
@@ -33,6 +33,8 @@ public class LoginCommand extends Command {
 
     private Nric loginNric;
     private Password loginPassword;
+    private Person personToBeLoggedIn;
+    private Nric nricToBeLoggedIn;
 
     public LoginCommand(Nric loginNric, Password loginPassword) {
         requireNonNull(loginNric);
@@ -51,8 +53,8 @@ public class LoginCommand extends Command {
         if (!isLoginCredentialsValid(model)) {
             throw new CommandException(INVALID_LOGIN_CREDENTIALS);
         } else {
-            SessionManager.loginToSession(loginNric);
-            return new CommandResult(String.format(LOGIN_SUCCESS, loginNric));
+            SessionManager.loginToSession(nricToBeLoggedIn);
+            return new CommandResult(String.format(LOGIN_SUCCESS, personToBeLoggedIn.getNric()));
         }
     }
 
@@ -61,11 +63,14 @@ public class LoginCommand extends Command {
      * Returns false if login NRIC tallies but login password is wrong, or NRIC is not found.
      */
     private boolean isLoginCredentialsValid(Model model) {
-        List<Person> allPersonsList = model.getFilteredPersonList();
+        // Grabs the list of ALL people in the address book.
+        List<Person> allPersonsList = model.getAddressBook().getPersonList();
 
         for (Person currPerson : allPersonsList) {
             if ((currPerson.getNric()).toString().equals(loginNric.toString())) {
                 if ((currPerson.getPassword()).toString().equals(loginPassword.toString())) {
+                    personToBeLoggedIn = currPerson;
+                    nricToBeLoggedIn = currPerson.getNric();
                     return true;
                 } else {
                     return false;

--- a/src/main/java/seedu/address/logic/commands/LoginCommand.java
+++ b/src/main/java/seedu/address/logic/commands/LoginCommand.java
@@ -29,6 +29,7 @@ public class LoginCommand extends Command {
 
     public static final String INVALID_LOGIN_CREDENTIALS = "Login failed. Incorrect NRIC and/or password.";
     public static final String LOGIN_SUCCESS = "Login successful. You are logged in as: %s";
+    public static final String ALREADY_LOGGED_IN = "You are already logged in. Logout first before logging in again.";
 
     private Nric loginNric;
     private Password loginPassword;
@@ -44,6 +45,9 @@ public class LoginCommand extends Command {
     @Override
     public CommandResult execute(Model model, CommandHistory history) throws CommandException {
         requireNonNull(model);
+        if (SessionManager.isLoggedIn()) {
+            throw new CommandException(ALREADY_LOGGED_IN);
+        }
         if (!isLoginCredentialsValid(model)) {
             throw new CommandException(INVALID_LOGIN_CREDENTIALS);
         } else {

--- a/src/main/java/seedu/address/logic/commands/LoginCommand.java
+++ b/src/main/java/seedu/address/logic/commands/LoginCommand.java
@@ -53,7 +53,7 @@ public class LoginCommand extends Command {
         if (!isLoginCredentialsValid(model)) {
             throw new CommandException(INVALID_LOGIN_CREDENTIALS);
         } else {
-            SessionManager.loginToSession(nricToBeLoggedIn);
+            SessionManager.loginToSession(model, nricToBeLoggedIn);
             return new CommandResult(String.format(LOGIN_SUCCESS, personToBeLoggedIn.getNric()));
         }
     }

--- a/src/main/java/seedu/address/logic/commands/LogoutCommand.java
+++ b/src/main/java/seedu/address/logic/commands/LogoutCommand.java
@@ -5,6 +5,7 @@ import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.SessionManager;
 
+//@@author jylee-git
 /**
  * Logs the user out of the application.
  */

--- a/src/main/java/seedu/address/logic/commands/SetPriorityLevelCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SetPriorityLevelCommand.java
@@ -1,0 +1,90 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+
+import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PRIORITYLEVEL;
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
+
+import java.util.List;
+
+import seedu.address.commons.core.Messages;
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.CommandHistory;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.SessionManager;
+import seedu.address.model.person.Person;
+import seedu.address.model.prioritylevel.PriorityLevel;
+import seedu.address.model.prioritylevel.PriorityLevelEnum;
+
+/**
+ * This command sets the priority level of other users.
+ */
+public class SetPriorityLevelCommand extends Command {
+
+    public static final String COMMAND_WORD = "setplvl";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Sets the priority level of the person identified "
+            + " by the index number used in the displayed person list.\n"
+            + "Parameters: INDEX (must be a positive integer) "
+            + PREFIX_PRIORITYLEVEL + "PRIORITYLEVEL\n"
+            + "Example: " + COMMAND_WORD + " 2 " + PREFIX_PRIORITYLEVEL + "3";
+
+    private static final String MESSAGE_CANNOT_EDIT_OWN_PLVL = "You can't edit your own priority level.";
+    private static final String MESSAGE_CHANGE_PLVL_SUCCESS = "Successfully changed the priority level of %s to %s";
+
+    private final Index index;
+    private final PriorityLevel priorityLevel;
+
+    public SetPriorityLevelCommand (Index index, PriorityLevel priorityLevel) {
+        requireAllNonNull (index, priorityLevel);
+        this.index = index;
+        this.priorityLevel = priorityLevel;
+    }
+
+    @Override
+    public CommandResult execute(Model model, CommandHistory history) throws CommandException {
+        requireNonNull(model);
+
+        if (!SessionManager.isLoggedIn()) {
+            throw new CommandException(SessionManager.NOT_LOGGED_IN);
+        }
+        /**
+         * Throws exception if user does not have the required access level.
+         */
+        if (!SessionManager.hasSufficientPriorityLevelForThisSession(model, PriorityLevelEnum.ADMINISTRATOR)) {
+            throw new CommandException(String.format(PriorityLevel.INSUFFICIENT_PRIORITY_LEVEL,
+                    PriorityLevelEnum.ADMINISTRATOR));
+        }
+
+        List<Person> lastShownList = model.getFilteredPersonList();
+
+        if (index.getZeroBased() >= lastShownList.size()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        }
+
+        Person personToEdit = lastShownList.get(index.getZeroBased());
+        if (personToEdit == SessionManager.getLoggedInPersonDetails(model)) {
+            throw new CommandException(MESSAGE_CANNOT_EDIT_OWN_PLVL);
+        }
+
+        Person editedPerson = new Person(
+                personToEdit.getName(),
+                personToEdit.getNric(),
+                personToEdit.getPassword(),
+                personToEdit.getPhone(),
+                personToEdit.getEmail(),
+                personToEdit.getDepartment(),
+                priorityLevel,
+                personToEdit.getAddress(),
+                personToEdit.getTags());
+
+        model.updatePerson(personToEdit, editedPerson);
+        model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
+        model.commitAddressBook();
+
+        return new CommandResult(String.format(MESSAGE_CHANGE_PLVL_SUCCESS,
+                editedPerson.getName(), priorityLevel));
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/SetPriorityLevelCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SetPriorityLevelCommand.java
@@ -18,6 +18,7 @@ import seedu.address.model.person.Person;
 import seedu.address.model.prioritylevel.PriorityLevel;
 import seedu.address.model.prioritylevel.PriorityLevelEnum;
 
+//@@author jylee-git
 /**
  * This command sets the priority level of other users.
  */

--- a/src/main/java/seedu/address/logic/commands/SetPriorityLevelCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SetPriorityLevelCommand.java
@@ -53,7 +53,7 @@ public class SetPriorityLevelCommand extends Command {
         /**
          * Throws exception if user does not have the required access level.
          */
-        if (!SessionManager.hasSufficientPriorityLevelForThisSession(model, PriorityLevelEnum.ADMINISTRATOR)) {
+        if (!SessionManager.hasSufficientPriorityLevelForThisSession(PriorityLevelEnum.ADMINISTRATOR)) {
             throw new CommandException(String.format(PriorityLevel.INSUFFICIENT_PRIORITY_LEVEL,
                     PriorityLevelEnum.ADMINISTRATOR));
         }

--- a/src/main/java/seedu/address/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddCommandParser.java
@@ -8,6 +8,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NRIC;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PASSWORD;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PRIORITYLEVEL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
 import java.util.Set;
@@ -23,6 +24,8 @@ import seedu.address.model.person.Nric;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
 import seedu.address.model.person.password.Password;
+import seedu.address.model.prioritylevel.PriorityLevel;
+import seedu.address.model.prioritylevel.PriorityLevelEnum;
 import seedu.address.model.tag.Tag;
 
 /**
@@ -38,7 +41,7 @@ public class AddCommandParser implements Parser<AddCommand> {
     public AddCommand parse(String args) throws ParseException {
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_NRIC, PREFIX_PHONE, PREFIX_EMAIL,
-                        PREFIX_DEPARTMENT, PREFIX_ADDRESS, PREFIX_TAG, PREFIX_PASSWORD);
+                        PREFIX_DEPARTMENT, PREFIX_ADDRESS, PREFIX_TAG, PREFIX_PASSWORD, PREFIX_PRIORITYLEVEL);
 
         if (!arePrefixesPresent(argMultimap, PREFIX_NAME, PREFIX_NRIC, PREFIX_ADDRESS, PREFIX_PHONE, PREFIX_EMAIL,
                 PREFIX_DEPARTMENT, PREFIX_PASSWORD) || !argMultimap.getPreamble().isEmpty()) {
@@ -54,7 +57,18 @@ public class AddCommandParser implements Parser<AddCommand> {
         Set<Tag> tagList = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG));
         Password password = ParserUtil.parsePassword(argMultimap.getValue(PREFIX_PASSWORD).get());
 
-        Person person = new Person(name, nric, password, phone, email, department, address, tagList);
+        /**
+         * Assign the lowest priority level as default if the prefix is missing.
+         */
+        PriorityLevel priorityLevel;
+        if (!arePrefixesPresent(argMultimap, PREFIX_PRIORITYLEVEL)) {
+            priorityLevel = new PriorityLevel(PriorityLevelEnum.BASIC.getPriorityLevelCode());
+        } else {
+            priorityLevel = ParserUtil.parsePriorityLevel(
+                    argMultimap.getValue(PREFIX_PRIORITYLEVEL).get());
+        }
+
+        Person person = new Person(name, nric, password, phone, email, department, priorityLevel, address, tagList);
 
         return new AddCommand(person);
     }

--- a/src/main/java/seedu/address/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddCommandParser.java
@@ -64,8 +64,7 @@ public class AddCommandParser implements Parser<AddCommand> {
         if (!arePrefixesPresent(argMultimap, PREFIX_PRIORITYLEVEL)) {
             priorityLevel = new PriorityLevel(PriorityLevelEnum.BASIC.getPriorityLevelCode());
         } else {
-            priorityLevel = ParserUtil.parsePriorityLevel(
-                    argMultimap.getValue(PREFIX_PRIORITYLEVEL).get());
+            priorityLevel = ParserUtil.parsePriorityLevel(argMultimap.getValue(PREFIX_PRIORITYLEVEL).get());
         }
 
         Person person = new Person(name, nric, password, phone, email, department, priorityLevel, address, tagList);

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -24,6 +24,7 @@ import seedu.address.logic.commands.LogoutCommand;
 import seedu.address.logic.commands.RedoCommand;
 import seedu.address.logic.commands.ScheduleCommand;
 import seedu.address.logic.commands.SelectCommand;
+import seedu.address.logic.commands.SetPriorityLevelCommand;
 import seedu.address.logic.commands.SetScheduleCommand;
 import seedu.address.logic.commands.UndoCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -111,6 +112,9 @@ public class AddressBookParser {
 
         case CheckCommand.COMMAND_WORD:
             return new CheckCommand();
+
+        case SetPriorityLevelCommand.COMMAND_WORD:
+            return new SetPriorityLevelCommandParser().parse(arguments);
 
 
         default:

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -17,4 +17,5 @@ public class CliSyntax {
     public static final Prefix PREFIX_DATE = new Prefix("date/");
     public static final Prefix PREFIX_APPROVAL = new Prefix("s/");
     public static final Prefix PREFIX_PASSWORD = new Prefix("pwd/");
+    public static final Prefix PREFIX_PRIORITYLEVEL = new Prefix("plvl/");
 }

--- a/src/main/java/seedu/address/logic/parser/LoginCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/LoginCommandParser.java
@@ -11,6 +11,7 @@ import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.Nric;
 import seedu.address.model.person.password.Password;
 
+//@@author jylee-git
 /**
  * Parses input arguments and creates a new LoginCommand object,
  */

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -224,7 +224,14 @@ public class ParserUtil {
      */
     public static PriorityLevel parsePriorityLevel(String priorityLevel) throws ParseException {
         requireNonNull(priorityLevel);
-        int priorityLevelCode = Integer.valueOf(priorityLevel.trim());
+
+        int priorityLevelCode;
+        try {
+            priorityLevelCode = Integer.valueOf(priorityLevel.trim());
+        } catch (NumberFormatException e) {
+            throw new ParseException(PriorityLevel.MESSAGE_PRIORITY_CONSTRAINTS);
+        }
+
         if (!PriorityLevelEnum.isValidPriorityLevel(priorityLevelCode)) {
             throw new ParseException(PriorityLevel.MESSAGE_PRIORITY_CONSTRAINTS);
         }

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -19,6 +19,8 @@ import seedu.address.model.person.Name;
 import seedu.address.model.person.Nric;
 import seedu.address.model.person.Phone;
 import seedu.address.model.person.password.Password;
+import seedu.address.model.prioritylevel.PriorityLevel;
+import seedu.address.model.prioritylevel.PriorityLevelEnum;
 import seedu.address.model.tag.Tag;
 
 /**
@@ -214,5 +216,18 @@ public class ParserUtil {
             throw new ParseException(Password.MESSAGE_PASSWORD_CONSTRAINTS);
         }
         return new Password(trimmedPassword);
+    }
+
+    /**
+     * Parses a {@code String priorityLevel} into a {@code PriorityLevel}.
+     * @throws ParseException is the priorityLevel does not fall between the valid levels.
+     */
+    public static PriorityLevel parsePriorityLevel(String priorityLevel) throws ParseException {
+        requireNonNull(priorityLevel);
+        int priorityLevelCode = Integer.valueOf(priorityLevel.trim());
+        if (!PriorityLevelEnum.isValidPriorityLevel(priorityLevelCode)) {
+            throw new ParseException(PriorityLevel.MESSAGE_PRIORITY_CONSTRAINTS);
+        }
+        return new PriorityLevel(priorityLevelCode);
     }
 }

--- a/src/main/java/seedu/address/logic/parser/SetPriorityLevelCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/SetPriorityLevelCommandParser.java
@@ -13,6 +13,7 @@ import seedu.address.logic.commands.SetPriorityLevelCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.prioritylevel.PriorityLevel;
 
+//@@author jylee-git
 /**
  * Parses the given {@code String} of arguments in the context of the SetPriorityLevelCommand
  * and returns a SetPriorityCommand object for execution.

--- a/src/main/java/seedu/address/logic/parser/SetPriorityLevelCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/SetPriorityLevelCommandParser.java
@@ -1,0 +1,52 @@
+package seedu.address.logic.parser;
+
+import static java.util.Objects.requireNonNull;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PRIORITYLEVEL;
+
+import java.util.stream.Stream;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.EditCommand;
+import seedu.address.logic.commands.SetPriorityLevelCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.prioritylevel.PriorityLevel;
+
+/**
+ * Parses the given {@code String} of arguments in the context of the SetPriorityLevelCommand
+ * and returns a SetPriorityCommand object for execution.
+ * @throws ParseException if the user input does not conform the expected format
+ */
+public class SetPriorityLevelCommandParser implements Parser<SetPriorityLevelCommand> {
+
+    @Override
+    public SetPriorityLevelCommand parse(String userInput) throws ParseException {
+        requireNonNull(userInput);
+        ArgumentMultimap argMultiMap = ArgumentTokenizer.tokenize(userInput, CliSyntax.PREFIX_PRIORITYLEVEL);
+
+        if (!arePrefixesPresent(argMultiMap, PREFIX_PRIORITYLEVEL)) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                    SetPriorityLevelCommand.MESSAGE_USAGE));
+        }
+
+        Index index;
+
+        try {
+            index = ParserUtil.parseIndex(argMultiMap.getPreamble());
+        } catch (ParseException pe) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditCommand.MESSAGE_USAGE), pe);
+        }
+
+        PriorityLevel priorityLevel = ParserUtil.parsePriorityLevel(argMultiMap.getValue(PREFIX_PRIORITYLEVEL).get());
+        return new SetPriorityLevelCommand(index, priorityLevel);
+    }
+
+    /**
+     * Returns true if none of the prefixes contains empty {@code Optional} values in the given
+     * {@code ArgumentMultimap}.
+     */
+    private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
+        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
+    }
+}

--- a/src/main/java/seedu/address/model/SessionManager.java
+++ b/src/main/java/seedu/address/model/SessionManager.java
@@ -10,6 +10,7 @@ import seedu.address.model.person.Person;
 import seedu.address.model.prioritylevel.PriorityLevel;
 import seedu.address.model.prioritylevel.PriorityLevelEnum;
 
+//@@author jylee-git
 /**
  * Stores the {@Code Nric} and {@code PriorityLevel} of the user who's logged in to the application.
  * Also manages the logging in and out of the current session.

--- a/src/main/java/seedu/address/model/SessionManager.java
+++ b/src/main/java/seedu/address/model/SessionManager.java
@@ -32,6 +32,9 @@ public class SessionManager {
     }
 
 
+    /**
+     * Logs out of the current session.
+     */
     public static void logOutSession() {
         loggedInNric = null;
         loggedInPriorityLevel = null;

--- a/src/main/java/seedu/address/model/SessionManager.java
+++ b/src/main/java/seedu/address/model/SessionManager.java
@@ -2,18 +2,26 @@ package seedu.address.model;
 
 import static java.util.Objects.requireNonNull;
 
+import java.util.List;
+
+import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.person.Nric;
+import seedu.address.model.person.Person;
+import seedu.address.model.prioritylevel.PriorityLevel;
+import seedu.address.model.prioritylevel.PriorityLevelEnum;
 
 /**
  * Stores the NRIC of the user who's logged in to the applicaion.
  * Also manages the logging in and out of the current session.
  */
 public class SessionManager {
+    public static final String NOT_LOGGED_IN = "This operation requires the user to be logged in!";
+
     private static Nric loggedInNric = null;
 
     /**
-     * Stores the NRIC of the successfully verified login into the session
-     * PRE-CONDITION: NRIC must be valid.
+     * Stores the {@code Nric} of the successfully logged in person into the session.
+     * PRE-CONDITION: Nric must be valid.
      * @param logInWithThisNric
      */
     public static void loginToSession(Nric logInWithThisNric) {
@@ -21,12 +29,19 @@ public class SessionManager {
         loggedInNric = logInWithThisNric;
     }
 
+
     public static void logOutSession() {
         loggedInNric = null;
     }
 
-    public static Nric getLoggedInSessionNric() {
-        requireNonNull(loggedInNric);
+    /**
+     * Returns the {@code Nric} of the logged in person.
+     * @throws CommandException if the app's not logged in.
+     */
+    public static Nric getLoggedInSessionNric() throws CommandException {
+        if (!isLoggedIn()) {
+            throw new CommandException(NOT_LOGGED_IN);
+        }
         return loggedInNric;
     }
 
@@ -38,5 +53,31 @@ public class SessionManager {
             return false;
         }
         return true;
+    }
+
+    /**
+     * Returns the {@code Person} of the person whose NRIC matches the one that's currently logged in.
+     */
+    public static Person getLoggedInPersonDetails(Model model) {
+        List<Person> allPersonsList = model.getAddressBook().getPersonList();
+        for (Person currPerson : allPersonsList) {
+            if (currPerson.getNric() == loggedInNric) {
+                return currPerson;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Returns true if current session has at least the required priority level for the operation.
+     * @throws CommandException if user's not logged in.
+     */
+    public static boolean hasSufficientPriorityLevelForThisSession(Model model, PriorityLevelEnum minimumPriorityLevel)
+            throws CommandException {
+        if (!isLoggedIn()) {
+            throw new CommandException(NOT_LOGGED_IN);
+        }
+        Person personToCheck = getLoggedInPersonDetails(model);
+        return PriorityLevel.isPriorityLevelAtLeastOf(personToCheck, minimumPriorityLevel);
     }
 }

--- a/src/main/java/seedu/address/model/SessionManager.java
+++ b/src/main/java/seedu/address/model/SessionManager.java
@@ -11,7 +11,7 @@ import seedu.address.model.prioritylevel.PriorityLevel;
 import seedu.address.model.prioritylevel.PriorityLevelEnum;
 
 /**
- * Stores the NRIC of the user who's logged in to the applicaion.
+ * Stores the {@Code Nric} and {@code PriorityLevel} of the user who's logged in to the application.
  * Also manages the logging in and out of the current session.
  */
 public class SessionManager {

--- a/src/main/java/seedu/address/model/SessionManager.java
+++ b/src/main/java/seedu/address/model/SessionManager.java
@@ -18,20 +18,23 @@ public class SessionManager {
     public static final String NOT_LOGGED_IN = "This operation requires the user to be logged in!";
 
     private static Nric loggedInNric = null;
+    private static PriorityLevel loggedInPriorityLevel = null;
 
     /**
      * Stores the {@code Nric} of the successfully logged in person into the session.
      * PRE-CONDITION: Nric must be valid.
      * @param logInWithThisNric
      */
-    public static void loginToSession(Nric logInWithThisNric) {
+    public static void loginToSession(Model model, Nric logInWithThisNric) {
         requireNonNull(logInWithThisNric);
         loggedInNric = logInWithThisNric;
+        loggedInPriorityLevel = getLoggedInPersonDetails(model).getPriorityLevel();
     }
 
 
     public static void logOutSession() {
         loggedInNric = null;
+        loggedInPriorityLevel = null;
     }
 
     /**
@@ -72,12 +75,20 @@ public class SessionManager {
      * Returns true if current session has at least the required priority level for the operation.
      * @throws CommandException if user's not logged in.
      */
-    public static boolean hasSufficientPriorityLevelForThisSession(Model model, PriorityLevelEnum minimumPriorityLevel)
-            throws CommandException {
+    public static boolean hasSufficientPriorityLevelForThisSession(
+            PriorityLevelEnum minimumPriorityLevel) throws CommandException {
         if (!isLoggedIn()) {
             throw new CommandException(NOT_LOGGED_IN);
         }
-        Person personToCheck = getLoggedInPersonDetails(model);
-        return PriorityLevel.isPriorityLevelAtLeastOf(personToCheck, minimumPriorityLevel);
+        return PriorityLevel.isPriorityLevelAtLeastOf(loggedInPriorityLevel, minimumPriorityLevel);
+    }
+
+    /**
+     * For test use only. Logs in with a defined priority level, which may be necessary for operations
+     * requiring admin rights.
+     */
+    protected static void forceLoginWith(String nric, int priorityLevel) {
+        loggedInNric = new Nric(nric);
+        loggedInPriorityLevel = new PriorityLevel(priorityLevel);
     }
 }

--- a/src/main/java/seedu/address/model/SessionManager.java
+++ b/src/main/java/seedu/address/model/SessionManager.java
@@ -13,6 +13,7 @@ public class SessionManager {
 
     /**
      * Stores the NRIC of the successfully verified login into the session
+     * PRE-CONDITION: NRIC must be valid.
      * @param logInWithThisNric
      */
     public static void loginToSession(Nric logInWithThisNric) {
@@ -25,6 +26,7 @@ public class SessionManager {
     }
 
     public static Nric getLoggedInSessionNric() {
+        requireNonNull(loggedInNric);
         return loggedInNric;
     }
 

--- a/src/main/java/seedu/address/model/person/Nric.java
+++ b/src/main/java/seedu/address/model/person/Nric.java
@@ -9,8 +9,8 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
  */
 public class Nric {
     public static final String MESSAGE_NRIC_CONSTRAINTS =
-            "NRIC should contain a prefix containing 'S', 'T', 'F' or 'G', followed by a seven-digit number,"
-                    + " followed by an alphabetical suffix; it should not be blank.";
+            "NRIC should contain a prefix containing capital 'S', 'T', 'F' or 'G', followed by a seven-digit number,"
+                    + " followed by a capital suffix; it should not be blank.";
     /*
      * Prefix should be a S, T, F or G, followed by a 7-digit number, followed by an alphabetical suffix.
      */

--- a/src/main/java/seedu/address/model/person/Nric.java
+++ b/src/main/java/seedu/address/model/person/Nric.java
@@ -4,6 +4,7 @@ import static java.util.Objects.requireNonNull;
 
 import static seedu.address.commons.util.AppUtil.checkArgument;
 
+//@@author jylee-git
 /**
  * Represents the unique identity of a person in the address book.
  */

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -8,6 +8,7 @@ import java.util.Objects;
 import java.util.Set;
 
 import seedu.address.model.person.password.Password;
+import seedu.address.model.prioritylevel.PriorityLevel;
 import seedu.address.model.tag.Tag;
 
 /**
@@ -23,6 +24,7 @@ public class Person {
     private final Email email;
     private final Department department;
     private final Password password;
+    private final PriorityLevel priorityLevel;
 
     // Data fields
     private final Address address;
@@ -32,14 +34,15 @@ public class Person {
      * Every field must be present and not null.
      */
     public Person(Name name, Nric nric, Password password, Phone phone, Email email, Department department,
-                  Address address, Set<Tag> tags) {
-        requireAllNonNull(name, nric, password, phone, email, department, address, tags);
+                  PriorityLevel priorityLevel, Address address, Set<Tag> tags) {
+        requireAllNonNull(name, nric, password, phone, email, department, priorityLevel, address, tags);
         this.name = name;
         this.nric = nric;
         this.password = password;
         this.phone = phone;
         this.email = email;
         this.department = department;
+        this.priorityLevel = priorityLevel;
         this.address = address;
         this.tags.addAll(tags);
     }
@@ -70,6 +73,10 @@ public class Person {
 
     public Address getAddress() {
         return address;
+    }
+
+    public PriorityLevel getPriorityLevel() {
+        return priorityLevel;
     }
 
     /**
@@ -113,13 +120,14 @@ public class Person {
                 && otherPerson.getPhone().equals(getPhone())
                 && otherPerson.getEmail().equals(getEmail())
                 && otherPerson.getAddress().equals(getAddress())
+                && otherPerson.getPriorityLevel().equals(getPriorityLevel())
                 && otherPerson.getTags().equals(getTags());
     }
 
     @Override
     public int hashCode() {
         // use this method for custom fields hashing instead of implementing your own
-        return Objects.hash(name, nric, password, phone, email, address, tags);
+        return Objects.hash(name, nric, password, phone, email, address, priorityLevel, tags);
     }
 
     /**
@@ -129,17 +137,19 @@ public class Person {
     public String toString() {
         final StringBuilder builder = new StringBuilder();
         builder.append(getName())
-                .append(" NRIC: ")
+                .append("\n NRIC: ")
                 .append(getNric())
-                .append(" Phone: ")
+                .append("\n Phone: ")
                 .append(getPhone())
-                .append(" Email: ")
+                .append("\n Email: ")
                 .append(getEmail())
-                .append(" Department: ")
+                .append("\n Department: ")
                 .append(getDepartment())
-                .append(" Address: ")
+                .append("\n Priority Level: ")
+                .append(getPriorityLevel())
+                .append("\n Address: ")
                 .append(getAddress())
-                .append(" Tags: ");
+                .append("\n Tags: ");
         getTags().forEach(builder::append);
         return builder.toString();
     }

--- a/src/main/java/seedu/address/model/person/password/Password.java
+++ b/src/main/java/seedu/address/model/person/password/Password.java
@@ -3,6 +3,7 @@ package seedu.address.model.person.password;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.AppUtil.checkArgument;
 
+//@@author jylee-git
 /**
  * Represents the password tagged to a NRIC that is used to login.
  */

--- a/src/main/java/seedu/address/model/prioritylevel/PriorityLevel.java
+++ b/src/main/java/seedu/address/model/prioritylevel/PriorityLevel.java
@@ -4,6 +4,8 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
 import static seedu.address.model.prioritylevel.PriorityLevelEnum.BASIC;
 import static seedu.address.model.prioritylevel.PriorityLevelEnum.IT_UNIT;
 
+import seedu.address.model.person.Person;
+
 /**
  * Represents the priority level access given to the person.
  * The lower the number, the higher the priority.
@@ -14,11 +16,32 @@ public class PriorityLevel {
             + IT_UNIT + " (" + IT_UNIT.getPriorityLevelCode() + " - highest) and "
             + BASIC + " (" + BASIC.getPriorityLevelCode() + " - lowest).";
 
+    public static final String INSUFFICIENT_PRIORITY_LEVEL = "You must have a priority level of at least %s to perform "
+            + " this operation.";
+
     public final int priorityLevelCode;
 
     public PriorityLevel(int priorityLevelCode) {
         checkArgument(PriorityLevelEnum.isValidPriorityLevel(priorityLevelCode), MESSAGE_PRIORITY_CONSTRAINTS);
         this.priorityLevelCode = priorityLevelCode;
+    }
+
+    /**
+     * Returns if and only if the priority level of the person is equal to the {@code requiredPriority}
+     */
+    public static boolean isPriorityLevelEqualTo (Person personToCheck, PriorityLevelEnum requiredPriority) {
+        return (requiredPriority.getPriorityLevelCode() == personToCheck.getPriorityLevel().priorityLevelCode);
+    }
+
+    /**
+     * Returns if the priority level of the person meets the min level of {@code minimumPriorityLevel}
+     */
+    public static boolean isPriorityLevelAtLeastOf (Person personToCheck, PriorityLevelEnum minimumPriorityLevel) {
+        if (personToCheck.getPriorityLevel().priorityLevelCode <= minimumPriorityLevel.getPriorityLevelCode()) {
+            return true;
+        } else {
+            return false;
+        }
     }
 
     @Override

--- a/src/main/java/seedu/address/model/prioritylevel/PriorityLevel.java
+++ b/src/main/java/seedu/address/model/prioritylevel/PriorityLevel.java
@@ -36,8 +36,9 @@ public class PriorityLevel {
     /**
      * Returns if the priority level of the person meets the min level of {@code minimumPriorityLevel}
      */
-    public static boolean isPriorityLevelAtLeastOf (Person personToCheck, PriorityLevelEnum minimumPriorityLevel) {
-        if (personToCheck.getPriorityLevel().priorityLevelCode <= minimumPriorityLevel.getPriorityLevelCode()) {
+    public static boolean isPriorityLevelAtLeastOf (PriorityLevel currPriorityLevel,
+                                                    PriorityLevelEnum minimumPriorityLevel) {
+        if (currPriorityLevel.priorityLevelCode <= minimumPriorityLevel.getPriorityLevelCode()) {
             return true;
         } else {
             return false;

--- a/src/main/java/seedu/address/model/prioritylevel/PriorityLevel.java
+++ b/src/main/java/seedu/address/model/prioritylevel/PriorityLevel.java
@@ -1,0 +1,35 @@
+package seedu.address.model.prioritylevel;
+
+import static seedu.address.commons.util.AppUtil.checkArgument;
+import static seedu.address.model.prioritylevel.PriorityLevelEnum.BASIC;
+import static seedu.address.model.prioritylevel.PriorityLevelEnum.IT_UNIT;
+
+/**
+ * Represents the priority level access given to the person.
+ * The lower the number, the higher the priority.
+ * Refer to {@code PriorityLevelEnum} for more details.
+ */
+public class PriorityLevel {
+    public static final String MESSAGE_PRIORITY_CONSTRAINTS = "Priority level should be between "
+            + IT_UNIT + " (" + IT_UNIT.getPriorityLevelCode() + " - highest) and "
+            + BASIC + " (" + BASIC.getPriorityLevelCode() + " - lowest).";
+
+    public final int priorityLevelCode;
+
+    public PriorityLevel(int priorityLevelCode) {
+        checkArgument(PriorityLevelEnum.isValidPriorityLevel(priorityLevelCode), MESSAGE_PRIORITY_CONSTRAINTS);
+        this.priorityLevelCode = priorityLevelCode;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof PriorityLevel // instanceof handles nulls
+                && priorityLevelCode == ((PriorityLevel) other).priorityLevelCode); // state check
+    }
+
+    @Override
+    public String toString() {
+        return PriorityLevelEnum.values()[priorityLevelCode].toString();
+    }
+}

--- a/src/main/java/seedu/address/model/prioritylevel/PriorityLevel.java
+++ b/src/main/java/seedu/address/model/prioritylevel/PriorityLevel.java
@@ -6,6 +6,7 @@ import static seedu.address.model.prioritylevel.PriorityLevelEnum.IT_UNIT;
 
 import seedu.address.model.person.Person;
 
+//@@author jylee-git
 /**
  * Represents the priority level access given to the person.
  * The lower the number, the higher the priority.

--- a/src/main/java/seedu/address/model/prioritylevel/PriorityLevelEnum.java
+++ b/src/main/java/seedu/address/model/prioritylevel/PriorityLevelEnum.java
@@ -1,5 +1,6 @@
 package seedu.address.model.prioritylevel;
 
+//@@author jylee-git
 /**
  * Priority level by descending order.
  * I.T. Unit highest priority, followed by administrator, followed by manager...

--- a/src/main/java/seedu/address/model/prioritylevel/PriorityLevelEnum.java
+++ b/src/main/java/seedu/address/model/prioritylevel/PriorityLevelEnum.java
@@ -1,0 +1,32 @@
+package seedu.address.model.prioritylevel;
+
+/**
+ * Priority level by descending order.
+ * I.T. Unit highest priority, followed by administrator, followed by manager...
+ */
+public enum PriorityLevelEnum {
+    IT_UNIT(0),
+    ADMINISTRATOR(1),
+    MANAGER(2),
+    BASIC(3);
+
+    private final int priorityLevelCode;
+
+    PriorityLevelEnum(int priorityLevelCode) {
+        this.priorityLevelCode = priorityLevelCode;
+    }
+
+    public int getPriorityLevelCode() {
+        return this.priorityLevelCode;
+    }
+
+    /**
+     * Returns true if the priorityLevel value is within the defined enum range as stated above.
+     */
+    public static boolean isValidPriorityLevel(int test) {
+        if (test >= IT_UNIT.getPriorityLevelCode() && test <= BASIC.getPriorityLevelCode()) {
+            return true;
+        }
+        return false;
+    }
+}

--- a/src/main/java/seedu/address/model/util/SampleDataUtil.java
+++ b/src/main/java/seedu/address/model/util/SampleDataUtil.java
@@ -14,6 +14,8 @@ import seedu.address.model.person.Nric;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
 import seedu.address.model.person.password.Password;
+import seedu.address.model.prioritylevel.PriorityLevel;
+import seedu.address.model.prioritylevel.PriorityLevelEnum;
 import seedu.address.model.tag.Tag;
 
 /**
@@ -24,27 +26,33 @@ public class SampleDataUtil {
         return new Person[] {
             new Person(new Name("Alex Yeoh"), new Nric("S9658471G"), new Password("NeuEr2018"), new Phone("87438807"),
                 new Email("alexyeoh@example.com"), new Department("Top Management"),
-                       new Address("Blk 30 Geylang Street 29, #06-40"),
+                new PriorityLevel(PriorityLevelEnum.MANAGER.getPriorityLevelCode()),
+                new Address("Blk 30 Geylang Street 29, #06-40"),
                 getTagSet("friends")),
             new Person(new Name("Bernice Yu"), new Nric("S9645580I"), new Password("NeuEr2018"), new Phone("99272758"),
                 new Email("berniceyu@example.com"), new Department("Senior Management"),
-                       new Address("Blk 30 Lorong 3 Serangoon Gardens, #07-18"),
+                new PriorityLevel(PriorityLevelEnum.MANAGER.getPriorityLevelCode()),
+                new Address("Blk 30 Lorong 3 Serangoon Gardens, #07-18"),
                 getTagSet("colleagues", "friends")),
             new Person(new Name("Charlotte Oliveiro"), new Nric("S1587485E"), new Password("NeuEr2018"),
                 new Phone("93210283"), new Email("charlotte@example.com"), new Department("Middle Management"),
+                new PriorityLevel(PriorityLevelEnum.BASIC.getPriorityLevelCode()),
                 new Address("Blk 11 Ang Mo Kio Street 74, #11-04"),
                 getTagSet("neighbours")),
             new Person(new Name("David Li"), new Nric("S5473621G"), new Password("NeuEr2018"), new Phone("91031282"),
                 new Email("lidavid@example.com"), new Department("Junior Management"),
-                       new Address("Blk 436 Serangoon Gardens Street 26, #16-43"),
+                new PriorityLevel(PriorityLevelEnum.BASIC.getPriorityLevelCode()),
+                new Address("Blk 436 Serangoon Gardens Street 26, #16-43"),
                 getTagSet("family")),
             new Person(new Name("Irfan Ibrahim"), new Nric("S8570520Q"), new Password("NeuEr2018"),
                 new Phone("92492021"), new Email("irfan@example.com"), new Department("Junior Management"),
-                       new Address("Blk 47 Tampines Street 20, #17-35"),
+                new PriorityLevel(PriorityLevelEnum.BASIC.getPriorityLevelCode()),
+                new Address("Blk 47 Tampines Street 20, #17-35"),
                 getTagSet("classmates")),
             new Person(new Name("Roy Balakrishnan"), new Nric("F5169584T"), new Password("NeuEr2018"),
                 new Phone("92624417"), new Email("royb@example.com"), new Department("Junior Management"),
-                       new Address("Blk 45 Aljunied Street 85, #11-31"),
+                new PriorityLevel(PriorityLevelEnum.BASIC.getPriorityLevelCode()),
+                new Address("Blk 45 Aljunied Street 85, #11-31"),
                 getTagSet("colleagues"))
         };
     }

--- a/src/main/java/seedu/address/model/util/SampleDataUtil.java
+++ b/src/main/java/seedu/address/model/util/SampleDataUtil.java
@@ -24,17 +24,17 @@ import seedu.address.model.tag.Tag;
 public class SampleDataUtil {
     public static Person[] getSamplePersons() {
         return new Person[] {
-            new Person(new Name("Alex Yeoh"), new Nric("S9658471G"), new Password("NeuEr2018"), new Phone("87438807"),
+            new Person(new Name("Alex Yeoh"), new Nric("S1234567E"), new Password("Password"), new Phone("87438807"),
                 new Email("alexyeoh@example.com"), new Department("Top Management"),
-                new PriorityLevel(PriorityLevelEnum.MANAGER.getPriorityLevelCode()),
+                new PriorityLevel(PriorityLevelEnum.ADMINISTRATOR.getPriorityLevelCode()),
                 new Address("Blk 30 Geylang Street 29, #06-40"),
-                getTagSet("friends")),
-            new Person(new Name("Bernice Yu"), new Nric("S9645580I"), new Password("NeuEr2018"), new Phone("99272758"),
+                getTagSet("friends", "ADMINISTRATOR", "S1234567E", "Password")),
+            new Person(new Name("Bernice Yu"), new Nric("T1234567E"), new Password("Password"), new Phone("99272758"),
                 new Email("berniceyu@example.com"), new Department("Senior Management"),
                 new PriorityLevel(PriorityLevelEnum.MANAGER.getPriorityLevelCode()),
                 new Address("Blk 30 Lorong 3 Serangoon Gardens, #07-18"),
-                getTagSet("colleagues", "friends")),
-            new Person(new Name("Charlotte Oliveiro"), new Nric("S1587485E"), new Password("NeuEr2018"),
+                getTagSet("colleagues", "friends", "MANAGER", "T1234567E", "Password")),
+            new Person(new Name("Charlotte Oliveiro"), new Nric("F1234567E"), new Password("Password"),
                 new Phone("93210283"), new Email("charlotte@example.com"), new Department("Middle Management"),
                 new PriorityLevel(PriorityLevelEnum.BASIC.getPriorityLevelCode()),
                 new Address("Blk 11 Ang Mo Kio Street 74, #11-04"),

--- a/src/main/java/seedu/address/storage/XmlAdaptedPerson.java
+++ b/src/main/java/seedu/address/storage/XmlAdaptedPerson.java
@@ -18,6 +18,8 @@ import seedu.address.model.person.Nric;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
 import seedu.address.model.person.password.Password;
+import seedu.address.model.prioritylevel.PriorityLevel;
+import seedu.address.model.prioritylevel.PriorityLevelEnum;
 import seedu.address.model.tag.Tag;
 
 /**
@@ -40,6 +42,8 @@ public class XmlAdaptedPerson {
     @XmlElement(required = true)
     private String department;
     @XmlElement(required = true)
+    private int priorityLevel;
+    @XmlElement(required = true)
     private String address;
 
     @XmlElement
@@ -55,13 +59,14 @@ public class XmlAdaptedPerson {
      * Constructs an {@code XmlAdaptedPerson} with the given person details.
      */
     public XmlAdaptedPerson(String name, String nric, String password, String phone, String email,
-                            String department, String address, List<XmlAdaptedTag> tagged) {
+                            String department, String priorityLevel, String address, List<XmlAdaptedTag> tagged) {
         this.name = name;
         this.nric = nric;
         this.password = password;
         this.phone = phone;
         this.email = email;
         this.department = department;
+        this.priorityLevel = Integer.valueOf(priorityLevel);
         this.address = address;
         if (tagged != null) {
             this.tagged = new ArrayList<>(tagged);
@@ -80,6 +85,7 @@ public class XmlAdaptedPerson {
         phone = source.getPhone().value;
         email = source.getEmail().value;
         department = source.getDepartment().fullDepartment;
+        priorityLevel = source.getPriorityLevel().priorityLevelCode;
         address = source.getAddress().value;
         tagged = source.getTags().stream()
                 .map(XmlAdaptedTag::new)
@@ -147,6 +153,11 @@ public class XmlAdaptedPerson {
         }
         final Department modelDepartment = new Department(department);
 
+        if (!PriorityLevelEnum.isValidPriorityLevel(priorityLevel)) {
+            throw new IllegalValueException(PriorityLevel.MESSAGE_PRIORITY_CONSTRAINTS);
+        }
+        final PriorityLevel modelPriorityLevel = new PriorityLevel(priorityLevel);
+
         if (address == null) {
             throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, Address.class.getSimpleName()));
         }
@@ -157,7 +168,7 @@ public class XmlAdaptedPerson {
 
         final Set<Tag> modelTags = new HashSet<>(personTags);
         return new Person(modelName, modelNric, modelPassword, modelPhone, modelEmail, modelDepartment,
-                modelAddress, modelTags);
+                modelPriorityLevel, modelAddress, modelTags);
     }
 
     @Override
@@ -177,6 +188,7 @@ public class XmlAdaptedPerson {
                 && Objects.equals(phone, otherPerson.phone)
                 && Objects.equals(email, otherPerson.email)
                 && Objects.equals(department, otherPerson.department)
+                && Objects.equals(priorityLevel, otherPerson.priorityLevel)
                 && Objects.equals(address, otherPerson.address)
                 && tagged.equals(otherPerson.tagged);
     }

--- a/src/test/data/XmlAddressBookStorageTest/invalidAndValidPersonAddressBook.xml
+++ b/src/test/data/XmlAddressBookStorageTest/invalidAndValidPersonAddressBook.xml
@@ -6,6 +6,7 @@
         <phone isPrivate="false">9482424</phone>
         <email isPrivate="false">hans@example.com</email>
         <department isPrivate="false">Junior Management</department>
+		<priorityLevel>0</priorityLevel>
         <address isPrivate="false">4th street</address>
     </persons>
     <!-- Person with invalid phone field -->
@@ -14,6 +15,7 @@
         <phone isPrivate="false">948asdf2424</phone>
         <email isPrivate="false">hans@example.com</email>
         <department isPrivate="false">Junior Management</department>
+		<priorityLevel>0</priorityLevel>
         <address isPrivate="false">4th street</address>
     </persons>
 </addressbook>

--- a/src/test/data/XmlAddressBookStorageTest/invalidPersonAddressBook.xml
+++ b/src/test/data/XmlAddressBookStorageTest/invalidPersonAddressBook.xml
@@ -6,6 +6,7 @@
         <phone isPrivate="false">9482424</phone>
         <email isPrivate="false">hans@example.com</email>
         <department isPrivate="false">Junior Management</department>
+		<priorityLevel>0</priorityLevel>
         <address isPrivate="false">4th street</address>
     </persons>
 </addressbook>

--- a/src/test/data/XmlSerializableAddressBookTest/duplicatePersonAddressBook.xml
+++ b/src/test/data/XmlSerializableAddressBookTest/duplicatePersonAddressBook.xml
@@ -8,6 +8,7 @@
         <phone>94351253</phone>
         <email>alice@example.com</email>
         <department>Junior Management</department>
+		<priorityLevel>0</priorityLevel>
         <address>123, Jurong West Ave 6, #08-111</address>
         <tagged>friends</tagged>
     </persons>
@@ -20,6 +21,7 @@
         <phone>94351253</phone>
         <email>pauline@example.com</email>
         <department>Junior Management</department>
+		<priorityLevel>0</priorityLevel>
         <address>4th street</address>
     </persons>
 

--- a/src/test/data/XmlSerializableAddressBookTest/invalidPersonAddressBook.xml
+++ b/src/test/data/XmlSerializableAddressBookTest/invalidPersonAddressBook.xml
@@ -6,6 +6,7 @@
         <phone isPrivate="false">9482424</phone>
         <email isPrivate="false">hans@exam!32ple</email>
         <department isPrivate="false">Junior Management</department>
+		<priorityLevel isPrivate="false">0</priorityLevel>
         <address isPrivate="false">4th street</address>
     </persons>
 </addressbook>

--- a/src/test/data/XmlSerializableAddressBookTest/typicalPersonsAddressBook.xml
+++ b/src/test/data/XmlSerializableAddressBookTest/typicalPersonsAddressBook.xml
@@ -8,6 +8,7 @@
         <phone>94351253</phone>
         <email>alice@example.com</email>
         <department>Junior Management</department>
+		<priorityLevel>0</priorityLevel>
         <address>123, Jurong West Ave 6, #08-111</address>
         <tagged>friends</tagged>
     </persons>
@@ -18,6 +19,7 @@
         <phone>98765432</phone>
         <email>johnd@example.com</email>
         <department>Junior Management</department>
+		<priorityLevel>0</priorityLevel>
         <address>311, Clementi Ave 2, #02-25</address>
         <tagged>owesMoney</tagged>
         <tagged>friends</tagged>
@@ -29,6 +31,7 @@
         <phone>95352563</phone>
         <email>heinz@example.com</email>
         <department>Junior Management</department>
+		<priorityLevel>0</priorityLevel>
         <address>wall street</address>
     </persons>
     <persons>
@@ -38,6 +41,7 @@
         <phone>87652533</phone>
         <email>cornelia@example.com</email>
         <department>Junior Management</department>
+		<priorityLevel>0</priorityLevel>
         <address>10th street</address>
         <tagged>friends</tagged>
     </persons>
@@ -48,6 +52,7 @@
         <phone>9482224</phone>
         <email>werner@example.com</email>
         <department>Junior Management</department>
+		<priorityLevel>0</priorityLevel>
         <address>michegan ave</address>
     </persons>
     <persons>
@@ -57,6 +62,7 @@
         <phone>9482427</phone>
         <email>lydia@example.com</email>
         <department>Junior Management</department>
+		<priorityLevel>0</priorityLevel>
         <address>little tokyo</address>
     </persons>
     <persons>
@@ -66,6 +72,7 @@
         <phone>9482442</phone>
         <email>anna@example.com</email>
         <department>Junior Management</department>
+		<priorityLevel>0</priorityLevel>
         <address>4th street</address>
     </persons>
 </addressbook>

--- a/src/test/data/XmlUtilTest/invalidPersonField.xml
+++ b/src/test/data/XmlUtilTest/invalidPersonField.xml
@@ -7,6 +7,7 @@
     <phone>9482asf424</phone>
     <email>hans@example</email>
     <department>Junior Management</department>
+	<priorityLevel>0</priorityLevel>
     <address>4th street</address>
     <tagged>friends</tagged>
 </person>

--- a/src/test/data/XmlUtilTest/missingPersonField.xml
+++ b/src/test/data/XmlUtilTest/missingPersonField.xml
@@ -6,6 +6,7 @@
     <phone>9482424</phone>
     <email>hans@example</email>
     <department>Junior Management</department>
+	<priorityLevel>0</priorityLevel>
     <address>4th street</address>
     <tagged>friends</tagged>
 </person>

--- a/src/test/data/XmlUtilTest/validAddressBook.xml
+++ b/src/test/data/XmlUtilTest/validAddressBook.xml
@@ -7,6 +7,7 @@
         <password isPrivate = "false">Asd321we5</password>
         <email isPrivate="false">hans@example.com</email>
         <department isPrivate="false">Junior Management</department>
+		<priorityLevel isPrivate="false">0</priorityLevel>
         <address isPrivate="false">4th street</address>
     </persons>
     <persons>
@@ -16,6 +17,7 @@
         <phone isPrivate="false">87249245</phone>
         <email isPrivate="false">ruth@example.com</email>
         <department isPrivate="false">Junior Management</department>
+		<priorityLevel isPrivate="false">0</priorityLevel>
         <address isPrivate="false">81th street</address>
     </persons>
     <persons>
@@ -25,6 +27,7 @@
         <phone isPrivate="false">95352563</phone>
         <email isPrivate="false">heinz@example.com</email>
         <department isPrivate="false">Junior Management</department>
+		<priorityLevel isPrivate="false">0</priorityLevel>
         <address isPrivate="false">wall street</address>
     </persons>
     <persons>
@@ -34,6 +37,7 @@
         <phone isPrivate="false">87652533</phone>
         <email isPrivate="false">cornelia@example.com</email>
         <department isPrivate="false">Junior Management</department>
+		<priorityLevel isPrivate="false">0</priorityLevel>
         <address isPrivate="false">10th street</address>
     </persons>
     <persons>
@@ -43,6 +47,7 @@
         <phone isPrivate="false">9482224</phone>
         <email isPrivate="false">werner@example.com</email>
         <department isPrivate="false">Junior Management</department>
+		<priorityLevel isPrivate="false">0</priorityLevel>
         <address isPrivate="false">michegan ave</address>
     </persons>
     <persons>
@@ -52,6 +57,7 @@
         <phone isPrivate="false">9482427</phone>
         <email isPrivate="false">lydia@example.com</email>
         <department isPrivate="false">Junior Management</department>
+		<priorityLevel isPrivate="false">0</priorityLevel>
         <address isPrivate="false">little tokyo</address>
     </persons>
     <persons>
@@ -61,6 +67,7 @@
         <phone isPrivate="false">9482442</phone>
         <email isPrivate="false">anna@example.com</email>
         <department isPrivate="false">Junior Management</department>
+		<priorityLevel isPrivate="false">0</priorityLevel>
         <address isPrivate="false">4th street</address>
     </persons>
     <persons>
@@ -70,6 +77,7 @@
         <phone isPrivate="false">8482424</phone>
         <email isPrivate="false">stefan@example.com</email>
         <department isPrivate="false">Junior Management</department>
+		<priorityLevel isPrivate="false">0</priorityLevel>
         <address isPrivate="false">little india</address>
     </persons>
     <persons>
@@ -79,6 +87,7 @@
         <phone isPrivate="false">8482131</phone>
         <email isPrivate="false">hans@example.com</email>
         <department isPrivate="false">Junior Management</department>
+		<priorityLevel isPrivate="false">0</priorityLevel>
         <address isPrivate="false">chicago ave</address>
     </persons>
 </addressbook>

--- a/src/test/data/XmlUtilTest/validPerson.xml
+++ b/src/test/data/XmlUtilTest/validPerson.xml
@@ -6,6 +6,7 @@
     <phone>9482424</phone>
     <email>hans@example</email>
     <department>Junior Management</department>
+	<priorityLevel>0</priorityLevel>
     <address>4th street</address>
     <tagged>friends</tagged>
 </person>

--- a/src/test/java/seedu/address/commons/util/XmlUtilTest.java
+++ b/src/test/java/seedu/address/commons/util/XmlUtilTest.java
@@ -42,6 +42,7 @@ public class XmlUtilTest {
     private static final String VALID_PHONE = "9482424";
     private static final String VALID_EMAIL = "hans@example";
     private static final String VALID_DEPARTMENT = "Junior Management";
+    private static final String VALID_PRIORITYLEVEL = "0";
     private static final String VALID_ADDRESS = "4th street";
     private static final List<XmlAdaptedTag> VALID_TAGS = Collections.singletonList(new XmlAdaptedTag("friends"));
 
@@ -83,7 +84,7 @@ public class XmlUtilTest {
         XmlAdaptedPerson actualPerson = XmlUtil.getDataFromFile(
                 MISSING_PERSON_FIELD_FILE, XmlAdaptedPersonWithRootElement.class);
         XmlAdaptedPerson expectedPerson = new XmlAdaptedPerson(
-                null, VALID_NRIC, VALID_PASSWORD, VALID_PHONE, VALID_EMAIL, VALID_DEPARTMENT,
+                null, VALID_NRIC, VALID_PASSWORD, VALID_PHONE, VALID_EMAIL, VALID_DEPARTMENT, VALID_PRIORITYLEVEL,
                 VALID_ADDRESS, VALID_TAGS);
         assertEquals(expectedPerson, actualPerson);
     }
@@ -94,7 +95,7 @@ public class XmlUtilTest {
                 INVALID_PERSON_FIELD_FILE, XmlAdaptedPersonWithRootElement.class);
         XmlAdaptedPerson expectedPerson = new XmlAdaptedPerson(
                 VALID_NAME, VALID_NRIC, VALID_PASSWORD, INVALID_PHONE, VALID_EMAIL, VALID_DEPARTMENT,
-                VALID_ADDRESS, VALID_TAGS);
+                VALID_PRIORITYLEVEL, VALID_ADDRESS, VALID_TAGS);
         assertEquals(expectedPerson, actualPerson);
     }
 
@@ -104,7 +105,7 @@ public class XmlUtilTest {
                 VALID_PERSON_FILE, XmlAdaptedPersonWithRootElement.class);
         XmlAdaptedPerson expectedPerson = new XmlAdaptedPerson(
                 VALID_NAME, VALID_NRIC, VALID_PASSWORD, VALID_PHONE, VALID_EMAIL, VALID_DEPARTMENT,
-                VALID_ADDRESS, VALID_TAGS);
+                VALID_PRIORITYLEVEL, VALID_ADDRESS, VALID_TAGS);
         assertEquals(expectedPerson, actualPerson);
     }
 

--- a/src/test/java/seedu/address/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/address/logic/LogicManagerTest.java
@@ -16,6 +16,8 @@ import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
+import seedu.address.model.prioritylevel.PriorityLevelEnum;
+import systemtests.SessionHelper;
 
 
 public class LogicManagerTest {
@@ -34,9 +36,11 @@ public class LogicManagerTest {
 
     @Test
     public void execute_commandExecutionError_throwsCommandException() {
-        String deleteCommand = "delete 9";
+        String deleteCommand = "delete 999";
+        SessionHelper.forceLoginWithPriorityLevelOf(PriorityLevelEnum.ADMINISTRATOR.getPriorityLevelCode());
         assertCommandException(deleteCommand, MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
         assertHistoryCorrect(deleteCommand);
+        SessionHelper.logoutOfSession();
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/AddCommandIntegrationTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandIntegrationTest.java
@@ -12,7 +12,9 @@ import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
 import seedu.address.model.person.Person;
+import seedu.address.model.prioritylevel.PriorityLevelEnum;
 import seedu.address.testutil.PersonBuilder;
+import systemtests.SessionHelper;
 
 /**
  * Contains integration tests (interaction with the Model) for {@code AddCommand}.
@@ -25,6 +27,7 @@ public class AddCommandIntegrationTest {
     @Before
     public void setUp() {
         model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+        SessionHelper.forceLoginWithPriorityLevelOf(PriorityLevelEnum.ADMINISTRATOR.getPriorityLevelCode());
     }
 
     @Test
@@ -44,6 +47,7 @@ public class AddCommandIntegrationTest {
         Person personInList = model.getAddressBook().getPersonList().get(0);
         assertCommandFailure(new AddCommand(personInList), model, commandHistory,
                 AddCommand.MESSAGE_DUPLICATE_PERSON);
+
     }
 
 }

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -58,7 +58,7 @@ public class AddCommandTest {
 
 
         thrown.expect(CommandException.class);
-        thrown.expectMessage(String.format(PriorityLevel.INSUFFICIENT_PRIORITY_LEVEL,PriorityLevelEnum.ADMINISTRATOR));
+        thrown.expectMessage(String.format(PriorityLevel.INSUFFICIENT_PRIORITY_LEVEL, PriorityLevelEnum.ADMINISTRATOR));
         addCommand.execute(modelStub, commandHistory);
         SessionHelper.forceLoginWithPriorityLevelOf(PriorityLevelEnum.ADMINISTRATOR.getPriorityLevelCode());
     }

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -9,6 +9,8 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.function.Predicate;
 
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -22,7 +24,10 @@ import seedu.address.model.ReadOnlyAddressBook;
 import seedu.address.model.ReadOnlyLeaveList;
 import seedu.address.model.leave.Leave;
 import seedu.address.model.person.Person;
+import seedu.address.model.prioritylevel.PriorityLevel;
+import seedu.address.model.prioritylevel.PriorityLevelEnum;
 import seedu.address.testutil.PersonBuilder;
+import systemtests.SessionHelper;
 
 public class AddCommandTest {
 
@@ -33,10 +38,29 @@ public class AddCommandTest {
 
     private CommandHistory commandHistory = new CommandHistory();
 
+    @Before
+    public void setUp() {
+        SessionHelper.forceLoginWithPriorityLevelOf(PriorityLevelEnum.ADMINISTRATOR.getPriorityLevelCode());
+    }
+
     @Test
     public void constructor_nullPerson_throwsNullPointerException() {
         thrown.expect(NullPointerException.class);
         new AddCommand(null);
+    }
+
+    @Test
+    public void execute_insufficientPriorityLevel_throwsCommandException() throws CommandException {
+        SessionHelper.forceLoginWithPriorityLevelOf(PriorityLevelEnum.BASIC.getPriorityLevelCode());
+        Person validPerson = new PersonBuilder().build();
+        AddCommand addCommand = new AddCommand(validPerson);
+        ModelStub modelStub = new ModelStubWithPerson(validPerson);
+
+
+        thrown.expect(CommandException.class);
+        thrown.expectMessage(String.format(PriorityLevel.INSUFFICIENT_PRIORITY_LEVEL,PriorityLevelEnum.ADMINISTRATOR));
+        addCommand.execute(modelStub, commandHistory);
+        SessionHelper.forceLoginWithPriorityLevelOf(PriorityLevelEnum.ADMINISTRATOR.getPriorityLevelCode());
     }
 
     @Test
@@ -84,6 +108,11 @@ public class AddCommandTest {
 
         // different person -> returns false
         assertFalse(addAliceCommand.equals(addBobCommand));
+    }
+
+    @After
+    public void tearDown() {
+        SessionHelper.logoutOfSession();
     }
 
     /**

--- a/src/test/java/seedu/address/logic/commands/CheckLoginStatusTest.java
+++ b/src/test/java/seedu/address/logic/commands/CheckLoginStatusTest.java
@@ -1,0 +1,63 @@
+package seedu.address.logic.commands;
+
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.CommandHistory;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.person.Nric;
+import seedu.address.model.person.Person;
+import seedu.address.model.person.password.Password;
+import seedu.address.model.prioritylevel.PriorityLevelEnum;
+import seedu.address.testutil.PersonBuilder;
+
+import systemtests.SessionHelper;
+
+public class CheckLoginStatusTest {
+
+    private static final Nric CORRECT_NRIC = new Nric("S0000001A");
+    private static final Password CORRECT_PASSWORD = new Password("NeUeR2018");
+
+    private Model model = new ModelManager();
+    private CommandHistory commandHistory = new CommandHistory();
+    private ModelManager expectedModel;
+    private Person personA;
+
+    /**
+     * Sets up an empty addressBook, then add a user inside; for purpose of CheckLoginStatus Command testing.
+     */
+    @BeforeEach
+    void setUp() throws CommandException {
+        SessionHelper.forceLoginWithPriorityLevelOf(PriorityLevelEnum.ADMINISTRATOR.getPriorityLevelCode());
+        personA = new PersonBuilder().withNric(CORRECT_NRIC.toString())
+                .withPassword(CORRECT_PASSWORD.toString()).build();
+        expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
+        expectedModel.addPerson(personA);
+        expectedModel.commitAddressBook();
+        new AddCommand(personA).execute(model, commandHistory);
+        SessionHelper.logoutOfSession();
+    }
+
+    @Test
+    void execute_checkLoginStatusTestPackage_success() throws CommandException {
+        // Phase 1: Not logged in initially, should show "You are not logged in".
+        CheckLoginStatusCommand checkLoginStatusCommand = new CheckLoginStatusCommand();
+        assertCommandSuccess(checkLoginStatusCommand, model, commandHistory,
+                CheckLoginStatusCommand.STATUS_NOT_LOGGED_IN, expectedModel);
+
+        // Phase 2: Logged in, should show that you are logged in with the logged in NRIC.
+        new LoginCommand(CORRECT_NRIC, CORRECT_PASSWORD).execute(model, commandHistory);
+        assertCommandSuccess(checkLoginStatusCommand, model, commandHistory,
+                String.format(CheckLoginStatusCommand.STATUS_LOGGED_IN, CORRECT_NRIC), expectedModel);
+
+        // Phase 3: Log out, then check again. Message should now show that you are not logged in.
+        new LogoutCommand().execute(model, commandHistory);
+        assertCommandSuccess(checkLoginStatusCommand, model, commandHistory,
+                CheckLoginStatusCommand.STATUS_NOT_LOGGED_IN, expectedModel);
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -78,7 +78,7 @@ public class CommandTestUtil {
     public static final String INVALID_TAG_DESC = " " + PREFIX_TAG + "hubby*"; // '*' not allowed in tags
     public static final String INVALID_PASSWORD_DESC = " " + PREFIX_PASSWORD + "A1e"; // Too short
     public static final String INVALID_NRIC_DESC = " " + PREFIX_NRIC + "W1234567Q"; //Incorrect prefix
-    public static final String INVALID_PRIORITYLEVEL_DESC = " " + PREFIX_PRIORITYLEVEL + "9999.52";  //Not an integer
+    public static final String INVALID_PRIORITYLEVEL_DESC = " " + PREFIX_PRIORITYLEVEL + "9999.52"; //Not an integer
 
     public static final String PREAMBLE_WHITESPACE = "\t  \r  \n";
     public static final String PREAMBLE_NON_EMPTY = "NonEmptyPreamble";

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -9,6 +9,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NRIC;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PASSWORD;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PRIORITYLEVEL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
 import java.util.ArrayList;
@@ -22,6 +23,7 @@ import seedu.address.model.AddressBook;
 import seedu.address.model.Model;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
 import seedu.address.model.person.Person;
+import seedu.address.model.prioritylevel.PriorityLevelEnum;
 import seedu.address.testutil.EditPersonDescriptorBuilder;
 
 /**
@@ -41,6 +43,9 @@ public class CommandTestUtil {
     public static final String VALID_EMAIL_BOB = "bob@example.com";
     public static final String VALID_DEPARTMENT_AMY = "Junior Management";
     public static final String VALID_DEPARTMENT_BOB = "Junior Management";
+    public static final int VALID_PRIORITYLEVEL_AMY = PriorityLevelEnum.MANAGER.getPriorityLevelCode();
+    public static final int VALID_PRIORITYLEVEL_BOB = PriorityLevelEnum.MANAGER.getPriorityLevelCode();
+
     public static final String VALID_ADDRESS_AMY = "Block 312, Amy Street 1";
     public static final String VALID_ADDRESS_BOB = "Block 123, Bobby Street 3";
     public static final String VALID_TAG_HUSBAND = "husband";
@@ -58,6 +63,8 @@ public class CommandTestUtil {
     public static final String EMAIL_DESC_BOB = " " + PREFIX_EMAIL + VALID_EMAIL_BOB;
     public static final String DEPARTMENT_DESC_AMY = " " + PREFIX_DEPARTMENT + VALID_DEPARTMENT_AMY;
     public static final String DEPARTMENT_DESC_BOB = " " + PREFIX_DEPARTMENT + VALID_DEPARTMENT_BOB;
+    public static final String PRIORITYLEVEL_DESC_AMY = " " + PREFIX_PRIORITYLEVEL + VALID_PRIORITYLEVEL_AMY;
+    public static final String PRIORITYLEVEL_DESC_BOB = " " + PREFIX_PRIORITYLEVEL + VALID_PRIORITYLEVEL_BOB;
     public static final String ADDRESS_DESC_AMY = " " + PREFIX_ADDRESS + VALID_ADDRESS_AMY;
     public static final String ADDRESS_DESC_BOB = " " + PREFIX_ADDRESS + VALID_ADDRESS_BOB;
     public static final String TAG_DESC_FRIEND = " " + PREFIX_TAG + VALID_TAG_FRIEND;
@@ -71,6 +78,7 @@ public class CommandTestUtil {
     public static final String INVALID_TAG_DESC = " " + PREFIX_TAG + "hubby*"; // '*' not allowed in tags
     public static final String INVALID_PASSWORD_DESC = " " + PREFIX_PASSWORD + "A1e"; // Too short
     public static final String INVALID_NRIC_DESC = " " + PREFIX_NRIC + "W1234567Q"; //Incorrect prefix
+    public static final String INVALID_PRIORITYLEVEL_DESC = " " + PREFIX_PRIORITYLEVEL + "9999.52";  //Not an integer
 
     public static final String PREAMBLE_WHITESPACE = "\t  \r  \n";
     public static final String PREAMBLE_NON_EMPTY = "NonEmptyPreamble";

--- a/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
@@ -10,6 +10,8 @@ import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 
 import seedu.address.commons.core.Messages;
@@ -19,6 +21,8 @@ import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
 import seedu.address.model.person.Person;
+import seedu.address.model.prioritylevel.PriorityLevelEnum;
+import systemtests.SessionHelper;
 
 /**
  * Contains integration tests (interaction with the Model, UndoCommand and RedoCommand) and unit tests for
@@ -28,6 +32,11 @@ public class DeleteCommandTest {
 
     private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
     private CommandHistory commandHistory = new CommandHistory();
+
+    @Before
+    public void setUp() {
+        SessionHelper.forceLoginWithPriorityLevelOf(PriorityLevelEnum.ADMINISTRATOR.getPriorityLevelCode());
+    }
 
     @Test
     public void execute_validIndexUnfilteredList_success() {
@@ -164,6 +173,11 @@ public class DeleteCommandTest {
 
         // different person -> returns false
         assertFalse(deleteFirstCommand.equals(deleteSecondCommand));
+    }
+
+    @After
+    public void tearDown() {
+        SessionHelper.logoutOfSession();
     }
 
     /**

--- a/src/test/java/seedu/address/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditCommandTest.java
@@ -16,6 +16,7 @@ import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
 import static seedu.address.testutil.TypicalPersons.BENSON;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
+import org.junit.Before;
 import org.junit.Test;
 
 import seedu.address.commons.core.Messages;
@@ -27,8 +28,10 @@ import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
 import seedu.address.model.person.Person;
+import seedu.address.model.prioritylevel.PriorityLevelEnum;
 import seedu.address.testutil.EditPersonDescriptorBuilder;
 import seedu.address.testutil.PersonBuilder;
+import systemtests.SessionHelper;
 
 /**
  * Contains integration tests (interaction with the Model, UndoCommand and RedoCommand) and unit tests for EditCommand.
@@ -36,13 +39,18 @@ import seedu.address.testutil.PersonBuilder;
 public class EditCommandTest {
 
     private static final Person ALICEFOREDIT = new PersonBuilder().withName("Alice Pauline")
-            .withNric("T2457888E").withPassword("ASd654")
+            .withNric("T2457888E").withPassword("ASd654").withPriorityLevel(0)
             .withAddress("123, Jurong West Ave 6, #08-111").withEmail("alice@gmail.com")
             .withPhone("85355255")
             .withTags("friends").build();
 
     private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
     private CommandHistory commandHistory = new CommandHistory();
+
+    @Before
+    public void setUp() {
+        SessionHelper.forceLoginWithPriorityLevelOf(PriorityLevelEnum.ADMINISTRATOR.getPriorityLevelCode());
+    }
 
     /**
      * PRE-CONDITION: NRIC of the person to edit MUST be the same.

--- a/src/test/java/seedu/address/logic/commands/LoginCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/LoginCommandTest.java
@@ -1,4 +1,85 @@
 package seedu.address.logic.commands;
 
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.CommandHistory;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.person.Nric;
+import seedu.address.model.person.Person;
+import seedu.address.model.person.password.Password;
+import seedu.address.model.prioritylevel.PriorityLevelEnum;
+import seedu.address.testutil.PersonBuilder;
+
+import systemtests.SessionHelper;
+
 public class LoginCommandTest {
+
+    private static final Nric CORRECT_NRIC = new Nric("S0000001A");
+    private static final Password CORRECT_PASSWORD = new Password("NeUeR2018");
+    private static final Nric WRONG_NRIC = new Nric("T2525254E");
+    private static final Password WRONG_PASSWORD = new Password("PASSword");
+
+    private Model model = new ModelManager();
+    private CommandHistory commandHistory = new CommandHistory();
+    private ModelManager expectedModel;
+    private Person personA;
+
+    @BeforeEach
+    public void setUp() throws CommandException {
+        SessionHelper.forceLoginWithPriorityLevelOf(PriorityLevelEnum.ADMINISTRATOR.getPriorityLevelCode());
+        personA = new PersonBuilder().withNric(CORRECT_NRIC.toString())
+                .withPassword(CORRECT_PASSWORD.toString()).build();
+        expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
+        expectedModel.addPerson(personA);
+        expectedModel.commitAddressBook();
+        new AddCommand(personA).execute(model, commandHistory);
+        SessionHelper.logoutOfSession();
+    }
+
+    @Test
+    public void constructor_nullParameters_throwsNullPointerException() {
+        Assertions.assertThrows(NullPointerException.class, () -> {
+            new LoginCommand(null, null);
+        });
+    }
+
+    @Test
+    public void execute_wrongNric_throwsCommandException() {
+        Assertions.assertThrows(CommandException.class, () -> {
+            new LoginCommand(WRONG_NRIC, CORRECT_PASSWORD).execute(model, commandHistory);
+        }, LoginCommand.INVALID_LOGIN_CREDENTIALS);
+    }
+
+    @Test
+    public void execute_wrongPassword_throwsCommandException() {
+        Assertions.assertThrows(CommandException.class, () -> {
+            new LoginCommand(CORRECT_NRIC, WRONG_PASSWORD).execute(model, commandHistory);
+        }, LoginCommand.INVALID_LOGIN_CREDENTIALS);
+    }
+
+    @Test
+    public void execute_validAccount_success() {
+        LoginCommand loginCommand = new LoginCommand(CORRECT_NRIC, CORRECT_PASSWORD);
+        assertCommandSuccess(loginCommand, model, commandHistory,
+                String.format(LoginCommand.LOGIN_SUCCESS, CORRECT_NRIC.toString()), expectedModel);
+    }
+
+    @Test
+    public void ececute_loginWithoutLoggingOut_throwsCommandException() {
+        SessionHelper.forceLoginWithPriorityLevelOf(PriorityLevelEnum.BASIC.getPriorityLevelCode());
+        try {
+            Assertions.assertThrows(CommandException.class, () -> {
+                new LoginCommand(CORRECT_NRIC, CORRECT_PASSWORD).execute(model, commandHistory);
+            }, LoginCommand.ALREADY_LOGGED_IN);
+        } finally {
+            SessionHelper.logoutOfSession();
+        }
+    }
 }

--- a/src/test/java/seedu/address/logic/commands/LoginCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/LoginCommandTest.java
@@ -1,0 +1,4 @@
+package seedu.address.logic.commands;
+
+public class LoginCommandTest {
+}

--- a/src/test/java/seedu/address/logic/commands/LoginCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/LoginCommandTest.java
@@ -2,6 +2,7 @@ package seedu.address.logic.commands;
 
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -81,5 +82,10 @@ public class LoginCommandTest {
         } finally {
             SessionHelper.logoutOfSession();
         }
+    }
+
+    @AfterEach
+    void tearDown() {
+        SessionHelper.logoutOfSession();
     }
 }

--- a/src/test/java/seedu/address/logic/commands/LoginCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/LoginCommandTest.java
@@ -20,6 +20,7 @@ import seedu.address.testutil.PersonBuilder;
 
 import systemtests.SessionHelper;
 
+//@@author jylee-git
 public class LoginCommandTest {
 
     private static final Nric CORRECT_NRIC = new Nric("S0000001A");
@@ -44,6 +45,7 @@ public class LoginCommandTest {
         SessionHelper.logoutOfSession();
     }
 
+    //Lambda function solution adopted from https://howtodoinjava.com/junit5/expected-exception-example/
     @Test
     public void constructor_nullParameters_throwsNullPointerException() {
         Assertions.assertThrows(NullPointerException.class, () -> {

--- a/src/test/java/seedu/address/model/person/NricTest.java
+++ b/src/test/java/seedu/address/model/person/NricTest.java
@@ -1,0 +1,41 @@
+package seedu.address.model.person;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import seedu.address.testutil.Assert;
+
+public class NricTest {
+
+    @Test
+    public void constructor_null_throwsNullPointerExceptio() {
+        Assert.assertThrows(NullPointerException.class, () -> new Nric(null));
+    }
+
+    @Test
+    public void constructor_invalidNric_throwsIllegalArgumentException() {
+        String invalidNric = "WAPIANG8E";
+        Assert.assertThrows(IllegalArgumentException.class, () -> new Nric(invalidNric));
+    }
+
+    @Test
+    public void isValidNric() {
+        //null NRIC param
+        Assert.assertThrows(NullPointerException.class, () -> Nric.isValidNric(null));
+
+        //invalid NRIC param
+        assertFalse(Nric.isValidNric("")); //Empty string
+        assertFalse(Nric.isValidNric(" ")); // Space only
+        assertFalse(Nric.isValidNric("Q1234567E")); //Invalid prefix
+        assertFalse(Nric.isValidNric("S1234567E9")); //Invalid length
+        assertFalse(Nric.isValidNric("T123R567E")); //Not a 7-digit number
+
+        //Valid NRIC param
+        assertTrue(Nric.isValidNric("S1234567E"));
+        assertTrue(Nric.isValidNric("F1234567I"));
+        assertTrue(Nric.isValidNric("G1234567E"));
+        assertTrue(Nric.isValidNric("T1234000E"));
+    }
+}

--- a/src/test/java/seedu/address/model/person/PrioritylevelTest.java
+++ b/src/test/java/seedu/address/model/person/PrioritylevelTest.java
@@ -1,0 +1,16 @@
+package seedu.address.model.person;
+
+import org.junit.Test;
+import seedu.address.model.prioritylevel.PriorityLevel;
+import seedu.address.testutil.Assert;
+
+public class PrioritylevelTest {
+
+    @Test
+    public void constructor_invalidArgument_throwsIllegalValueException() {
+        //Priority levels out of range
+        Assert.assertThrows(IllegalArgumentException.class, () -> new PriorityLevel(999));
+        Assert.assertThrows(IllegalArgumentException.class, () -> new PriorityLevel(-20));
+    }
+
+}

--- a/src/test/java/seedu/address/model/person/PrioritylevelTest.java
+++ b/src/test/java/seedu/address/model/person/PrioritylevelTest.java
@@ -1,6 +1,7 @@
 package seedu.address.model.person;
 
 import org.junit.Test;
+
 import seedu.address.model.prioritylevel.PriorityLevel;
 import seedu.address.testutil.Assert;
 

--- a/src/test/java/seedu/address/storage/XmlAdaptedPersonTest.java
+++ b/src/test/java/seedu/address/storage/XmlAdaptedPersonTest.java
@@ -18,6 +18,7 @@ import seedu.address.model.person.Name;
 import seedu.address.model.person.Nric;
 import seedu.address.model.person.Phone;
 import seedu.address.model.person.password.Password;
+import seedu.address.model.prioritylevel.PriorityLevel;
 import seedu.address.testutil.Assert;
 
 public class XmlAdaptedPersonTest {
@@ -27,6 +28,7 @@ public class XmlAdaptedPersonTest {
     private static final String INVALID_DEPARTMENT = "Juni@r D@p@rtm@nt";
     private static final String INVALID_EMAIL = "example.com";
     private static final String INVALID_TAG = "#friend";
+    private static final String INVALID_PRIORITYLEVEL = "-5";
     private static final String INVALID_NRIC = "Z9420873T";
     private static final String INVALID_PASSWORD = "@ert";
 
@@ -36,6 +38,7 @@ public class XmlAdaptedPersonTest {
     private static final String VALID_PHONE = BENSON.getPhone().toString();
     private static final String VALID_EMAIL = BENSON.getEmail().toString();
     private static final String VALID_DEPARTMENT = BENSON.getDepartment().toString();
+    private static final String VALID_PRIORITYLEVEL = Integer.toString(BENSON.getPriorityLevel().priorityLevelCode);
     private static final String VALID_ADDRESS = BENSON.getAddress().toString();
     private static final List<XmlAdaptedTag> VALID_TAGS = BENSON.getTags().stream()
             .map(XmlAdaptedTag::new)
@@ -51,7 +54,7 @@ public class XmlAdaptedPersonTest {
     public void toModelType_invalidName_throwsIllegalValueException() {
         XmlAdaptedPerson person =
                 new XmlAdaptedPerson(INVALID_NAME, VALID_NRIC, VALID_PASSWORD, VALID_PHONE, VALID_EMAIL,
-                        VALID_DEPARTMENT, VALID_ADDRESS, VALID_TAGS);
+                        VALID_DEPARTMENT, VALID_PRIORITYLEVEL, VALID_ADDRESS, VALID_TAGS);
         String expectedMessage = Name.MESSAGE_NAME_CONSTRAINTS;
         Assert.assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -59,7 +62,7 @@ public class XmlAdaptedPersonTest {
     @Test
     public void toModelType_nullName_throwsIllegalValueException() {
         XmlAdaptedPerson person = new XmlAdaptedPerson(null, VALID_NRIC, VALID_PASSWORD, VALID_PHONE,
-                VALID_EMAIL, VALID_DEPARTMENT, VALID_ADDRESS, VALID_TAGS);
+                VALID_EMAIL, VALID_DEPARTMENT, VALID_PRIORITYLEVEL, VALID_ADDRESS, VALID_TAGS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Name.class.getSimpleName());
         Assert.assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -67,7 +70,7 @@ public class XmlAdaptedPersonTest {
     @Test
     public void toModelType_invalidNric_throwsIllegalValueException() {
         XmlAdaptedPerson person = new XmlAdaptedPerson(VALID_NAME, INVALID_NRIC, VALID_PASSWORD, VALID_PHONE,
-                VALID_EMAIL, VALID_DEPARTMENT, VALID_ADDRESS, VALID_TAGS);
+                VALID_EMAIL, VALID_DEPARTMENT, VALID_PRIORITYLEVEL, VALID_ADDRESS, VALID_TAGS);
         String expectedMessage = Nric.MESSAGE_NRIC_CONSTRAINTS;
         Assert.assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -75,7 +78,7 @@ public class XmlAdaptedPersonTest {
     @Test
     public void toModelType_nullNric_throwsIllegalValueException() {
         XmlAdaptedPerson person = new XmlAdaptedPerson(VALID_NAME, null, VALID_PASSWORD, VALID_PHONE,
-                VALID_EMAIL, VALID_DEPARTMENT, VALID_ADDRESS, VALID_TAGS);
+                VALID_EMAIL, VALID_DEPARTMENT, VALID_PRIORITYLEVEL, VALID_ADDRESS, VALID_TAGS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Nric.class.getSimpleName());
         Assert.assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -83,7 +86,7 @@ public class XmlAdaptedPersonTest {
     @Test
     public void toModelType_invalidPassword_throwsIllegalValueException() {
         XmlAdaptedPerson person = new XmlAdaptedPerson(VALID_NAME, VALID_NRIC, INVALID_PASSWORD, VALID_PHONE,
-                VALID_EMAIL, VALID_DEPARTMENT, VALID_ADDRESS, VALID_TAGS);
+                VALID_EMAIL, VALID_DEPARTMENT, VALID_PRIORITYLEVEL, VALID_ADDRESS, VALID_TAGS);
         String expectedMessage = Password.MESSAGE_PASSWORD_CONSTRAINTS;
         Assert.assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -91,7 +94,7 @@ public class XmlAdaptedPersonTest {
     @Test
     public void toModelType_nullPassword_throwsIllegalValueException() {
         XmlAdaptedPerson person = new XmlAdaptedPerson(VALID_NAME, VALID_NRIC, null, VALID_PHONE,
-                VALID_EMAIL, VALID_DEPARTMENT, VALID_ADDRESS, VALID_TAGS);
+                VALID_EMAIL, VALID_DEPARTMENT, VALID_PRIORITYLEVEL, VALID_ADDRESS, VALID_TAGS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Password.class.getSimpleName());
         Assert.assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -100,7 +103,7 @@ public class XmlAdaptedPersonTest {
     public void toModelType_invalidPhone_throwsIllegalValueException() {
         XmlAdaptedPerson person =
                 new XmlAdaptedPerson(VALID_NAME, VALID_NRIC, VALID_PASSWORD, INVALID_PHONE, VALID_EMAIL,
-                        VALID_DEPARTMENT, VALID_ADDRESS, VALID_TAGS);
+                        VALID_DEPARTMENT, VALID_PRIORITYLEVEL, VALID_ADDRESS, VALID_TAGS);
         String expectedMessage = Phone.MESSAGE_PHONE_CONSTRAINTS;
         Assert.assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -108,7 +111,7 @@ public class XmlAdaptedPersonTest {
     @Test
     public void toModelType_nullPhone_throwsIllegalValueException() {
         XmlAdaptedPerson person = new XmlAdaptedPerson(VALID_NAME, VALID_NRIC, VALID_PASSWORD, null,
-                VALID_EMAIL, VALID_DEPARTMENT, VALID_ADDRESS, VALID_TAGS);
+                VALID_EMAIL, VALID_DEPARTMENT, VALID_PRIORITYLEVEL, VALID_ADDRESS, VALID_TAGS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Phone.class.getSimpleName());
         Assert.assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -117,7 +120,7 @@ public class XmlAdaptedPersonTest {
     public void toModelType_invalidEmail_throwsIllegalValueException() {
         XmlAdaptedPerson person =
                 new XmlAdaptedPerson(VALID_NAME, VALID_NRIC, VALID_PASSWORD, VALID_PHONE, INVALID_EMAIL,
-                        VALID_DEPARTMENT, VALID_ADDRESS, VALID_TAGS);
+                        VALID_DEPARTMENT, VALID_PRIORITYLEVEL, VALID_ADDRESS, VALID_TAGS);
         String expectedMessage = Email.MESSAGE_EMAIL_CONSTRAINTS;
         Assert.assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -125,7 +128,7 @@ public class XmlAdaptedPersonTest {
     @Test
     public void toModelType_nullEmail_throwsIllegalValueException() {
         XmlAdaptedPerson person = new XmlAdaptedPerson(VALID_NAME, VALID_NRIC, VALID_PASSWORD, VALID_PHONE,
-                null, VALID_DEPARTMENT, VALID_ADDRESS, VALID_TAGS);
+                null, VALID_DEPARTMENT, VALID_PRIORITYLEVEL, VALID_ADDRESS, VALID_TAGS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Email.class.getSimpleName());
         Assert.assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -134,7 +137,7 @@ public class XmlAdaptedPersonTest {
     public void toModelType_invalidDepartment_throwsIllegalValueException() {
         XmlAdaptedPerson person =
                 new XmlAdaptedPerson(VALID_NAME, VALID_NRIC, VALID_PASSWORD, VALID_PHONE, VALID_EMAIL,
-                        INVALID_DEPARTMENT, VALID_ADDRESS, VALID_TAGS);
+                        INVALID_DEPARTMENT, VALID_PRIORITYLEVEL, VALID_ADDRESS, VALID_TAGS);
         String expectedMessage = Department.MESSAGE_DEPARTMENT_CONSTRAINTS;
         Assert.assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -142,7 +145,7 @@ public class XmlAdaptedPersonTest {
     @Test
     public void toModelType_nullDepartment_throwsIllegalValueException() {
         XmlAdaptedPerson person = new XmlAdaptedPerson(VALID_NAME, VALID_NRIC, VALID_PASSWORD, VALID_PHONE,
-                VALID_EMAIL, null, VALID_ADDRESS, VALID_TAGS);
+                VALID_EMAIL, null, VALID_PRIORITYLEVEL, VALID_ADDRESS, VALID_TAGS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Department.class.getSimpleName());
         Assert.assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -151,7 +154,7 @@ public class XmlAdaptedPersonTest {
     public void toModelType_invalidAddress_throwsIllegalValueException() {
         XmlAdaptedPerson person =
                 new XmlAdaptedPerson(VALID_NAME, VALID_NRIC, VALID_PASSWORD, VALID_PHONE, VALID_EMAIL,
-                        VALID_DEPARTMENT, INVALID_ADDRESS, VALID_TAGS);
+                        VALID_DEPARTMENT, VALID_PRIORITYLEVEL, INVALID_ADDRESS, VALID_TAGS);
         String expectedMessage = Address.MESSAGE_ADDRESS_CONSTRAINTS;
         Assert.assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -159,7 +162,7 @@ public class XmlAdaptedPersonTest {
     @Test
     public void toModelType_nullAddress_throwsIllegalValueException() {
         XmlAdaptedPerson person = new XmlAdaptedPerson(VALID_NAME, VALID_NRIC, VALID_PASSWORD, VALID_PHONE,
-                VALID_EMAIL, VALID_DEPARTMENT, null, VALID_TAGS);
+                VALID_EMAIL, VALID_DEPARTMENT, VALID_PRIORITYLEVEL, null, VALID_TAGS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Address.class.getSimpleName());
         Assert.assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -170,8 +173,15 @@ public class XmlAdaptedPersonTest {
         invalidTags.add(new XmlAdaptedTag(INVALID_TAG));
         XmlAdaptedPerson person =
                 new XmlAdaptedPerson(VALID_NAME, VALID_NRIC, VALID_PASSWORD, VALID_PHONE,
-                        VALID_EMAIL, VALID_DEPARTMENT, VALID_ADDRESS, invalidTags);
+                        VALID_EMAIL, VALID_DEPARTMENT, VALID_PRIORITYLEVEL, VALID_ADDRESS, invalidTags);
         Assert.assertThrows(IllegalValueException.class, person::toModelType);
     }
 
+    @Test
+    public void toModelType_invalidPriorityLevel_throwsIllegalValueException() {
+        XmlAdaptedPerson person = new XmlAdaptedPerson(VALID_NAME, VALID_NRIC, VALID_PASSWORD, VALID_PHONE,
+                VALID_EMAIL, VALID_DEPARTMENT, INVALID_PRIORITYLEVEL, VALID_ADDRESS, VALID_TAGS);
+        String expectedMessage = String.format(PriorityLevel.MESSAGE_PRIORITY_CONSTRAINTS);
+        Assert.assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
+    }
 }

--- a/src/test/java/seedu/address/testutil/EditPersonDescriptorBuilder.java
+++ b/src/test/java/seedu/address/testutil/EditPersonDescriptorBuilder.java
@@ -41,6 +41,7 @@ public class EditPersonDescriptorBuilder {
         descriptor.setPhone(person.getPhone());
         descriptor.setEmail(person.getEmail());
         descriptor.setDepartment(person.getDepartment());
+        descriptor.setPriorityLevel(person.getPriorityLevel());
         descriptor.setAddress(person.getAddress());
         descriptor.setTags(person.getTags());
     }

--- a/src/test/java/seedu/address/testutil/PersonBuilder.java
+++ b/src/test/java/seedu/address/testutil/PersonBuilder.java
@@ -11,6 +11,7 @@ import seedu.address.model.person.Nric;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
 import seedu.address.model.person.password.Password;
+import seedu.address.model.prioritylevel.PriorityLevel;
 import seedu.address.model.tag.Tag;
 import seedu.address.model.util.SampleDataUtil;
 
@@ -26,6 +27,7 @@ public class PersonBuilder {
     public static final String DEFAULT_ADDRESS = "123, Jurong West Ave 6, #08-111";
     public static final String DEFAULT_NRIC = "S1458574G";
     public static final String DEFAULT_PASSWORD = "PQWOei23";
+    public static final int DEFAULT_PRIORITYLEVEL = 3;
 
     private Name name;
     private Nric nric;
@@ -33,6 +35,7 @@ public class PersonBuilder {
     private Phone phone;
     private Email email;
     private Department department;
+    private PriorityLevel priorityLevel;
     private Address address;
     private Set<Tag> tags;
 
@@ -43,6 +46,7 @@ public class PersonBuilder {
         phone = new Phone(DEFAULT_PHONE);
         email = new Email(DEFAULT_EMAIL);
         department = new Department(DEFAULT_DEPARTMENT);
+        priorityLevel = new PriorityLevel(DEFAULT_PRIORITYLEVEL);
         address = new Address(DEFAULT_ADDRESS);
         tags = new HashSet<>();
     }
@@ -57,6 +61,7 @@ public class PersonBuilder {
         phone = personToCopy.getPhone();
         email = personToCopy.getEmail();
         department = personToCopy.getDepartment();
+        priorityLevel = personToCopy.getPriorityLevel();
         address = personToCopy.getAddress();
         tags = new HashSet<>(personToCopy.getTags());
     }
@@ -110,6 +115,14 @@ public class PersonBuilder {
     }
 
     /**
+     * Sets the {@code Department} of the {@code Person} that we are building.
+     */
+    public PersonBuilder withPriorityLevel(int plvl) {
+        this.priorityLevel = new PriorityLevel(plvl);
+        return this;
+    }
+
+    /**
      * Sets the {@code EmployeeId} of the {@code Person} that we are building.
      */
     public PersonBuilder withNric(String nric) {
@@ -126,7 +139,7 @@ public class PersonBuilder {
     }
 
     public Person build() {
-        return new Person(name, nric, password, phone, email, department, address, tags);
+        return new Person(name, nric, password, phone, email, department, priorityLevel, address, tags);
     }
 
 }

--- a/src/test/java/seedu/address/testutil/PersonUtil.java
+++ b/src/test/java/seedu/address/testutil/PersonUtil.java
@@ -7,6 +7,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NRIC;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PASSWORD;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PRIORITYLEVEL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
 import java.util.Set;
@@ -39,6 +40,7 @@ public class PersonUtil {
         sb.append(PREFIX_PHONE + person.getPhone().value + " ");
         sb.append(PREFIX_EMAIL + person.getEmail().value + " ");
         sb.append(PREFIX_DEPARTMENT + person.getDepartment().fullDepartment + " ");
+        sb.append(PREFIX_PRIORITYLEVEL + Integer.toString(person.getPriorityLevel().priorityLevelCode) + " ");
         sb.append(PREFIX_ADDRESS + person.getAddress().value + " ");
         person.getTags().stream().forEach(
             s -> sb.append(PREFIX_TAG + s.tagName + " ")

--- a/src/test/java/seedu/address/testutil/TypicalPersons.java
+++ b/src/test/java/seedu/address/testutil/TypicalPersons.java
@@ -30,35 +30,35 @@ public class TypicalPersons {
     public static final Person ALICE = new PersonBuilder().withName("Alice Pauline")
             .withNric("T2457888E").withPassword("ASd654")
             .withAddress("123, Jurong West Ave 6, #08-111").withEmail("alice@example.com")
-            .withPhone("94351253")
+            .withPhone("94351253").withPriorityLevel(0)
             .withTags("friends").build();
     public static final Person BENSON = new PersonBuilder().withName("Benson Meier")
             .withNric("T2457846E").withPassword("ASd654")
             .withAddress("311, Clementi Ave 2, #02-25")
-            .withEmail("johnd@example.com").withPhone("98765432")
+            .withEmail("johnd@example.com").withPhone("98765432").withPriorityLevel(0)
             .withTags("owesMoney", "friends").build();
     public static final Person CARL = new PersonBuilder().withName("Carl Kurz").withPhone("95352563")
-            .withNric("T2456699E").withPassword("ASd654")
+            .withNric("T2456699E").withPassword("ASd654").withPriorityLevel(0)
             .withEmail("heinz@example.com").withAddress("wall street").build();
     public static final Person DANIEL = new PersonBuilder().withName("Daniel Meier").withPhone("87652533")
-            .withNric("S2457855E").withPassword("ASd654")
+            .withNric("S2457855E").withPassword("ASd654").withPriorityLevel(0)
             .withEmail("cornelia@example.com").withAddress("10th street").withTags("friends").build();
     public static final Person ELLE = new PersonBuilder().withName("Elle Meyer").withPhone("9482224")
-            .withNric("T0257855E").withPassword("ASd654")
+            .withNric("T0257855E").withPassword("ASd654").withPriorityLevel(0)
             .withEmail("werner@example.com").withAddress("michegan ave").build();
     public static final Person FIONA = new PersonBuilder().withName("Fiona Kunz").withPhone("9482427")
-            .withNric("T2457005E").withPassword("ASd654")
+            .withNric("T2457005E").withPassword("ASd654").withPriorityLevel(0)
             .withEmail("lydia@example.com").withAddress("little tokyo").build();
     public static final Person GEORGE = new PersonBuilder().withName("George Best").withPhone("9482442")
-            .withNric("T2457775E").withPassword("ASd654")
+            .withNric("T2457775E").withPassword("ASd654").withPriorityLevel(0)
             .withEmail("anna@example.com").withAddress("4th street").build();
 
     // Manually added
     public static final Person HOON = new PersonBuilder().withName("Hoon Meier").withPhone("8482424")
-            .withNric("T2457465H").withPassword("ASd654")
+            .withNric("T2457465H").withPassword("ASd654").withPriorityLevel(0)
             .withEmail("stefan@example.com").withAddress("little india").build();
     public static final Person IDA = new PersonBuilder().withName("Ida Mueller").withPhone("8482131")
-            .withNric("T1234567E").withPassword("ASd654")
+            .withNric("T1234567E").withPassword("ASd654").withPriorityLevel(0)
             .withEmail("hans@example.com").withAddress("chicago ave").build();
 
     // Manually added - Person's details found in {@code CommandTestUtil}

--- a/src/test/java/systemtests/AddCommandSystemTest.java
+++ b/src/test/java/systemtests/AddCommandSystemTest.java
@@ -23,6 +23,7 @@ import static seedu.address.logic.commands.CommandTestUtil.PASSWORD_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.PASSWORD_DESC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.PHONE_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.PHONE_DESC_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.PRIORITYLEVEL_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.TAG_DESC_FRIEND;
 import static seedu.address.logic.commands.CommandTestUtil.TAG_DESC_HUSBAND;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_ADDRESS_BOB;
@@ -40,6 +41,7 @@ import static seedu.address.testutil.TypicalPersons.HOON;
 import static seedu.address.testutil.TypicalPersons.IDA;
 import static seedu.address.testutil.TypicalPersons.KEYWORD_MATCHING_MEIER;
 
+import org.junit.Before;
 import org.junit.Test;
 
 import seedu.address.commons.core.Messages;
@@ -56,11 +58,19 @@ import seedu.address.model.person.Nric;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
 import seedu.address.model.person.password.Password;
+import seedu.address.model.prioritylevel.PriorityLevelEnum;
 import seedu.address.model.tag.Tag;
 import seedu.address.testutil.PersonBuilder;
 import seedu.address.testutil.PersonUtil;
 
 public class AddCommandSystemTest extends AddressBookSystemTest {
+
+    @Override
+    @Before
+    public void setUp() {
+        super.setUp();
+        SessionHelper.forceLoginWithPriorityLevelOf(PriorityLevelEnum.ADMINISTRATOR.getPriorityLevelCode());
+    }
 
     @Test
     public void add() {

--- a/src/test/java/systemtests/AddCommandSystemTest.java
+++ b/src/test/java/systemtests/AddCommandSystemTest.java
@@ -23,7 +23,6 @@ import static seedu.address.logic.commands.CommandTestUtil.PASSWORD_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.PASSWORD_DESC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.PHONE_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.PHONE_DESC_BOB;
-import static seedu.address.logic.commands.CommandTestUtil.PRIORITYLEVEL_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.TAG_DESC_FRIEND;
 import static seedu.address.logic.commands.CommandTestUtil.TAG_DESC_HUSBAND;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_ADDRESS_BOB;

--- a/src/test/java/systemtests/DeleteCommandSystemTest.java
+++ b/src/test/java/systemtests/DeleteCommandSystemTest.java
@@ -10,6 +10,7 @@ import static seedu.address.testutil.TestUtil.getPerson;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 import static seedu.address.testutil.TypicalPersons.KEYWORD_MATCHING_MEIER;
 
+import org.junit.Before;
 import org.junit.Test;
 
 import seedu.address.commons.core.Messages;
@@ -19,11 +20,19 @@ import seedu.address.logic.commands.RedoCommand;
 import seedu.address.logic.commands.UndoCommand;
 import seedu.address.model.Model;
 import seedu.address.model.person.Person;
+import seedu.address.model.prioritylevel.PriorityLevelEnum;
 
 public class DeleteCommandSystemTest extends AddressBookSystemTest {
 
     private static final String MESSAGE_INVALID_DELETE_COMMAND_FORMAT =
             String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE);
+
+    @Override
+    @Before
+    public void setUp() {
+        super.setUp();
+        SessionHelper.forceLoginWithPriorityLevelOf(PriorityLevelEnum.ADMINISTRATOR.getPriorityLevelCode());
+    }
 
     @Test
     public void delete() {

--- a/src/test/java/systemtests/EditCommandSystemTest.java
+++ b/src/test/java/systemtests/EditCommandSystemTest.java
@@ -32,6 +32,7 @@ import static seedu.address.testutil.TypicalPersons.BENSON;
 import static seedu.address.testutil.TypicalPersons.BOB;
 import static seedu.address.testutil.TypicalPersons.KEYWORD_MATCHING_MEIER;
 
+import org.junit.Before;
 import org.junit.Test;
 
 import seedu.address.commons.core.Messages;
@@ -45,10 +46,18 @@ import seedu.address.model.person.Email;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
+import seedu.address.model.prioritylevel.PriorityLevelEnum;
 import seedu.address.model.tag.Tag;
 import seedu.address.testutil.PersonBuilder;
 
 public class EditCommandSystemTest extends AddressBookSystemTest {
+
+    @Override
+    @Before
+    public void setUp() {
+        super.setUp();
+        SessionHelper.forceLoginWithPriorityLevelOf(PriorityLevelEnum.ADMINISTRATOR.getPriorityLevelCode());
+    }
 
     @Test
     public void edit() {

--- a/src/test/java/systemtests/EditCommandSystemTest.java
+++ b/src/test/java/systemtests/EditCommandSystemTest.java
@@ -73,7 +73,7 @@ public class EditCommandSystemTest extends AddressBookSystemTest {
         Index index = INDEX_FIRST_PERSON;
         String command = " " + EditCommand.COMMAND_WORD + "  " + index.getOneBased() + "  " + NAME_DESC_BOB + "  "
                 + PHONE_DESC_BOB + " " + EMAIL_DESC_BOB + "  " + ADDRESS_DESC_BOB + " " + TAG_DESC_HUSBAND + " ";
-        Person editedPerson = new PersonBuilder(BOB).withNric(ALICE.getNric().toString())
+        Person editedPerson = new PersonBuilder(BOB).withNric(ALICE.getNric().toString()).withPriorityLevel(0)
                 .withTags(VALID_TAG_HUSBAND).build();
         assertCommandSuccess(command, index, editedPerson);
 
@@ -90,7 +90,7 @@ public class EditCommandSystemTest extends AddressBookSystemTest {
         assertCommandSuccess(command, model, expectedResultMessage);
 
         /* Case: edit a person with new values same as existing values -> edited */
-        Person editedBob = new PersonBuilder(BOB).withNric(ALICE.getNric().toString())
+        Person editedBob = new PersonBuilder(BOB).withNric(ALICE.getNric().toString()).withPriorityLevel(0)
                 .withTags(VALID_TAG_HUSBAND).build();
         command = EditCommand.COMMAND_WORD + " " + index.getOneBased() + NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB
                 + ADDRESS_DESC_BOB + TAG_DESC_HUSBAND;
@@ -103,7 +103,8 @@ public class EditCommandSystemTest extends AddressBookSystemTest {
         assertNotEquals(getModel().getFilteredPersonList().get(index.getZeroBased()), BOB);
         command = EditCommand.COMMAND_WORD + " " + index.getOneBased() + NAME_DESC_AMY + PHONE_DESC_BOB + EMAIL_DESC_BOB
                 + ADDRESS_DESC_BOB + TAG_DESC_FRIEND + TAG_DESC_HUSBAND;
-        editedPerson = new PersonBuilder(BOB).withName(VALID_NAME_AMY).withNric(BENSON.getNric().toString()).build();
+        editedPerson = new PersonBuilder(BOB).withName(VALID_NAME_AMY).withNric(BENSON.getNric().toString())
+                .withPriorityLevel(0).build();
         assertCommandSuccess(command, index, editedPerson);
 
         /* Case: edit a person with new values same as another person's values but with different phone and email
@@ -112,7 +113,7 @@ public class EditCommandSystemTest extends AddressBookSystemTest {
         index = INDEX_SECOND_PERSON;
         command = EditCommand.COMMAND_WORD + " " + index.getOneBased() + NAME_DESC_BOB + PHONE_DESC_AMY + EMAIL_DESC_AMY
                 + ADDRESS_DESC_BOB + TAG_DESC_FRIEND + TAG_DESC_HUSBAND;
-        editedPerson = new PersonBuilder(BOB).withPhone(VALID_PHONE_AMY)
+        editedPerson = new PersonBuilder(BOB).withPhone(VALID_PHONE_AMY).withPriorityLevel(0)
                 .withNric(BENSON.getNric().toString()).withEmail(VALID_EMAIL_AMY).build();
         assertCommandSuccess(command, index, editedPerson);
 
@@ -150,7 +151,7 @@ public class EditCommandSystemTest extends AddressBookSystemTest {
         showAllPersons();
         index = INDEX_FIRST_PERSON;
         selectPerson(index);
-        Person editedAlice = new PersonBuilder(AMY).withNric(ALICE.getNric().toString())
+        Person editedAlice = new PersonBuilder(AMY).withNric(ALICE.getNric().toString()).withPriorityLevel(0)
                 .withPassword(ALICE.getPassword().toString()).build();
         command = EditCommand.COMMAND_WORD + " " + index.getOneBased() + NAME_DESC_AMY + PHONE_DESC_AMY + EMAIL_DESC_AMY
                 + ADDRESS_DESC_AMY + TAG_DESC_FRIEND;

--- a/src/test/java/systemtests/SessionHelper.java
+++ b/src/test/java/systemtests/SessionHelper.java
@@ -2,7 +2,7 @@ package systemtests;
 
 import seedu.address.model.SessionManager;
 
-
+//@@author jylee-git
 /**
  * Enables short-circuit login using with a NRIC number, to facilitate in operations that require admin rights.
  */

--- a/src/test/java/systemtests/SessionHelper.java
+++ b/src/test/java/systemtests/SessionHelper.java
@@ -1,0 +1,22 @@
+package systemtests;
+
+import seedu.address.model.SessionManager;
+
+
+/**
+ * Enables short-circuit login using with a NRIC number, to facilitate in operations that require admin rights.
+ */
+public class SessionHelper extends SessionManager{
+
+    /**
+     * Force login with a NRIC with highest priority level, to enable operations
+     * that require admin rights.
+     */
+    public static void forceLoginWithPriorityLevelOf(int priorityLevel) {
+        forceLoginWith("F9999999P", priorityLevel);
+    }
+
+    public static void logoutOfSession() {
+        SessionManager.logOutSession();
+    }
+}

--- a/src/test/java/systemtests/SessionHelper.java
+++ b/src/test/java/systemtests/SessionHelper.java
@@ -6,7 +6,7 @@ import seedu.address.model.SessionManager;
 /**
  * Enables short-circuit login using with a NRIC number, to facilitate in operations that require admin rights.
  */
-public class SessionHelper extends SessionManager{
+public class SessionHelper extends SessionManager {
 
     /**
      * Force login with a NRIC with highest priority level, to enable operations

--- a/src/test/java/systemtests/SystemTestSetupHelper.java
+++ b/src/test/java/systemtests/SystemTestSetupHelper.java
@@ -10,8 +10,6 @@ import guitests.guihandles.MainWindowHandle;
 import javafx.stage.Stage;
 import seedu.address.TestApp;
 import seedu.address.model.ReadOnlyAddressBook;
-import seedu.address.model.SessionManager;
-import seedu.address.model.person.Nric;
 
 /**
  * Contains helper methods that system tests require.

--- a/src/test/java/systemtests/SystemTestSetupHelper.java
+++ b/src/test/java/systemtests/SystemTestSetupHelper.java
@@ -10,6 +10,8 @@ import guitests.guihandles.MainWindowHandle;
 import javafx.stage.Stage;
 import seedu.address.TestApp;
 import seedu.address.model.ReadOnlyAddressBook;
+import seedu.address.model.SessionManager;
+import seedu.address.model.person.Nric;
 
 /**
  * Contains helper methods that system tests require.


### PR DESCRIPTION
###  [BUG FIXES]
- Fixed a bug whereby user tries to log in again when the application already has a logged in session. User must now log out before one is able to login.
- Fixed a bug whereby users are unable to login from a filtered AddressBook

### [ADD IMPLEMENTATION]
- Added priorityLevel field
- Added PriorityLevel.class and PriorityLevelEnum.class
- Added methods to get the Person details from the current logged in session's NRIC.
- Added methods to check if the logged in session meets the required priority levels to perform certain operations.
- Implemented setPriorityLevel command.
   > Requires admin priority level to set the priority of anyone other than yourself.

### [EDIT EXISTING FEATURES]
- addCommand modified to take in priorityLevel parameters.
   > If priorityLevel field omitted, lowest priorityLevel will be set by default.
- editCommand modified for priorityLevel.
   > Note: User is unable to modify NRIC, password and priorityLevel.
- addCommand, deleteCommand now requires priority level of minimum, an aministrator, to perform the operation.
- deleteCommand now stops admins from deleting themselves

### [TO-DO]
- [Medium Priority] Restrict edit function to user's own data fields.
- [Medium Priority] Implement change password.


This resolves #31 
This resolves #38 
This resolves #40 