### PR TITLE
Updated codes related to PE1 issue reports

### DIFF
--- a/docs/UserGuide.adoc
+++ b/docs/UserGuide.adoc
@@ -479,7 +479,7 @@ Returns any person having names `Betsy`, `Tim`, or `John`
 ====
 * Does not require the user to log in before using the command.
 ====
-Shows the sorted list of the employees or departments in the address book.
+Sorts the employees or departments of the current list in sorted order.
 The list can be sorted in ascending or descending order. +
 Format: `sort FIELD ORDER`
 

--- a/src/main/java/seedu/address/logic/parser/SetDepartmentCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/SetDepartmentCommandParser.java
@@ -28,6 +28,9 @@ public class SetDepartmentCommandParser implements Parser<SetDepartmentCommand> 
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
                     SetDepartmentCommand.MESSAGE_USAGE));
         }
+        if (!didPrefixAppearOnlyOnce(userInput, PREFIX_DEPARTMENT.toString())) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, SetDepartmentCommand.MESSAGE_USAGE));
+        }
 
         Index index;
 
@@ -48,5 +51,12 @@ public class SetDepartmentCommandParser implements Parser<SetDepartmentCommand> 
      */
     private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
         return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
+    }
+
+    /**
+     * Checks whether prefixes appeared more than once within the argument
+     */
+    public boolean didPrefixAppearOnlyOnce(String argument, String prefix) {
+        return argument.indexOf(prefix) == argument.lastIndexOf(prefix);
     }
 }

--- a/src/main/java/seedu/address/model/person/Department.java
+++ b/src/main/java/seedu/address/model/person/Department.java
@@ -17,7 +17,7 @@ public class Department {
      * The first character of the address must not be a whitespace,
      * otherwise " " (a blank string) becomes a valid input.
      */
-    public static final String DEPARTMENT_VALIDATION_REGEX = "(\\p{Alpha}+ )+Management";
+    public static final String DEPARTMENT_VALIDATION_REGEX = "([a-zA-Z ]+)Management";
 
     public final String fullDepartment;
 

--- a/src/main/java/seedu/address/model/person/UniquePersonList.java
+++ b/src/main/java/seedu/address/model/person/UniquePersonList.java
@@ -122,7 +122,7 @@ public class UniquePersonList implements Iterable<Person> {
         Comparator<Person> nameComparator = new Comparator<Person>() {
             @Override
             public int compare(Person p1, Person p2) {
-                return p1.getName().fullName.compareTo(p2.getName().fullName);
+                return p1.getName().fullName.compareToIgnoreCase(p2.getName().fullName);
             }
         };
 
@@ -134,7 +134,7 @@ public class UniquePersonList implements Iterable<Person> {
             public int compare(Person p1, Person p2) {
                 String x1 = p1.getDepartment().fullDepartment;
                 String x2 = p2.getDepartment().fullDepartment;
-                int sComp = x1.compareTo(x2);
+                int sComp = x1.compareToIgnoreCase(x2);
 
                 if (sComp != 0) {
                     return sComp;
@@ -142,7 +142,7 @@ public class UniquePersonList implements Iterable<Person> {
 
                 String x3 = p1.getName().fullName;
                 String x4 = p2.getName().fullName;
-                return x3.compareTo(x4);
+                return x3.compareToIgnoreCase(x4);
             }
         };
 

--- a/src/test/java/seedu/address/logic/parser/SetDepartmentCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/SetDepartmentCommandParserTest.java
@@ -32,6 +32,14 @@ public class SetDepartmentCommandParserTest {
     }
 
     @Test
+    public void parse_extraPrefix_failure() {
+        String setDepartmentCommand = "1 " + CliSyntax.PREFIX_DEPARTMENT + "Junior Management "
+                + CliSyntax.PREFIX_DEPARTMENT + "Senior Management";
+        assertParseFailure(parser, setDepartmentCommand,
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, SetDepartmentCommand.MESSAGE_USAGE));
+    }
+
+    @Test
     public void parse_invalidIndex_failure() {
         String setDepartmentCommand = "invalid " + CliSyntax.PREFIX_DEPARTMENT
                 + "Junior Management";


### PR DESCRIPTION
- Fixed the input for Department names to be able to input extra spaces.
- Fixed sort command.
- SetDepartmentCommand can now allow only just 1 Department prefix.
- Updated description for SortCommand.

This resolves #116 
This resolves #118 
This resolves #120 
This resolves #122  
This resolves #123 
This resolves #124  