### PR TITLE
V1.4: Modified modus operandi when invalid dataset exception is caught when reading AddressBook.xml

### DIFF
--- a/docs/UserGuide.adoc
+++ b/docs/UserGuide.adoc
@@ -718,9 +718,9 @@ There is no need to save manually.
 === Filtering/Sorting
 •	*<<Listing all persons : `list`, List employee list>>*: `list`
 •	*<<Locating persons by name: `find`, Find employee>>*: `find KEYWORD [MORE_KEYWORDS]`
-•	*<<Sort address book contacts: `sort`, Sort address book contacts>>*: `sort name asc`
+•	*<<Sort address book contacts: `sort`, Sort address book contacts>>*: `sort FIELD ORDER`
 •	*<<List department : `listdepartment`, List available departments>>*: `listdepartment`
-•	*<<Filtering department : `filterdepartment`, Filter departments>>*: `filterdepartment junior`
+•	*<<Filtering department : `filterdepartment`, Filter departments>>*: `filterdepartment KEYWORD [MORE KEYWORDS]`
 
 === Miscellaneous
 •	*<<Viewing help : `help`, Help>>*: `help`

--- a/src/main/java/seedu/address/MainApp.java
+++ b/src/main/java/seedu/address/MainApp.java
@@ -1,5 +1,6 @@
 package seedu.address;
 
+import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Optional;
@@ -44,7 +45,7 @@ import seedu.address.ui.UiManager;
  */
 public class MainApp extends Application {
 
-    public static final Version VERSION = new Version(1, 1, 10, true);
+    public static final Version VERSION = new Version(3, 1, 10, true);
 
     private static final Logger logger = LogsCenter.getLogger(MainApp.class);
 
@@ -97,8 +98,10 @@ public class MainApp extends Application {
             }
             initialData = addressBookOptional.orElseGet(SampleDataUtil::getSampleAddressBook);
         } catch (DataConversionException e) {
-            logger.warning("Data file not in the correct format. Will be starting with an empty AddressBook");
-            initialData = new AddressBook();
+            logger.warning("Data file not in the correct format. Will delete data/AddressBook.xml and start with"
+                    + " a sample AddressBook.");
+            storage.deleteAddressBook();
+            initialData = SampleDataUtil.getSampleAddressBook();
         } catch (IOException e) {
             logger.warning("Problem while reading from the file. Will be starting with an empty AddressBook");
             initialData = new AddressBook();

--- a/src/main/java/seedu/address/MainApp.java
+++ b/src/main/java/seedu/address/MainApp.java
@@ -1,6 +1,5 @@
 package seedu.address;
 
-import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Optional;
@@ -11,6 +10,7 @@ import com.google.common.eventbus.Subscribe;
 import javafx.application.Application;
 import javafx.application.Platform;
 import javafx.stage.Stage;
+
 import seedu.address.commons.core.Config;
 import seedu.address.commons.core.EventsCenter;
 import seedu.address.commons.core.LogsCenter;

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -325,9 +325,23 @@ public class ParserUtil {
 
 
     //=========================== CONDITION CHECKERS ================================================
-    public static boolean hasOnlyOnePrefixOfSpecifiedType(String userInput, Prefix... prefixes) {
 
+    /**
+     * Checks and returns true if there is only one prefix of each type.
+     *
+     * WARNING: This method WILL NOT WORK for AddCommand and DeleteCommand due to address parameters accepting
+     *  input which contains string prefix of other prefixes.
+     */
+    public static boolean hasOnlyOnePrefixOfSpecifiedType(String userInput, Prefix... prefixes) throws ParseException {
+        for (Prefix prefix : prefixes) {
+            if (prefix.equals(CliSyntax.PREFIX_ADDRESS)) {
+                throw new ParseException("Exception thrown because address prefix is entered.");
+            }
+            if (userInput.indexOf(prefix.getPrefix()) == userInput.lastIndexOf(prefix.getPrefix())) {
+                return false;
+            }
+        }
         //return argument.indexOf(prefix) == argument.lastIndexOf(prefix);
-        return false;
+        return true;
     }
 }

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -322,4 +322,12 @@ public class ParserUtil {
         }
         return new WorkingRate(trimmedWorkingRate);
     }
+
+
+    //=========================== CONDITION CHECKERS ================================================
+    public static boolean hasOnlyOnePrefixOfSpecifiedType(String userInput, Prefix... prefixes) {
+
+        //return argument.indexOf(prefix) == argument.lastIndexOf(prefix);
+        return false;
+    }
 }

--- a/src/main/java/seedu/address/logic/parser/SetPriorityLevelCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/SetPriorityLevelCommandParser.java
@@ -39,6 +39,11 @@ public class SetPriorityLevelCommandParser implements Parser<SetPriorityLevelCom
                     SetPriorityLevelCommand.MESSAGE_USAGE), pe);
         }
 
+        if (ParserUtil.hasOnlyOnePrefixOfSpecifiedType(userInput, PREFIX_PRIORITYLEVEL)) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                    SetPriorityLevelCommand.MESSAGE_USAGE));
+        }
+
         PriorityLevel priorityLevel = ParserUtil.parsePriorityLevel(argMultiMap.getValue(PREFIX_PRIORITYLEVEL).get());
         return new SetPriorityLevelCommand(index, priorityLevel);
     }

--- a/src/main/java/seedu/address/storage/AddressBookStorage.java
+++ b/src/main/java/seedu/address/storage/AddressBookStorage.java
@@ -42,4 +42,8 @@ public interface AddressBookStorage {
      */
     void saveAddressBook(ReadOnlyAddressBook addressBook, Path filePath) throws IOException;
 
+    /**
+     * Deletes the AddressBook as specified in the UserPrefs
+     */
+    void deleteAddressBook();
 }

--- a/src/main/java/seedu/address/storage/StorageManager.java
+++ b/src/main/java/seedu/address/storage/StorageManager.java
@@ -1,5 +1,6 @@
 package seedu.address.storage;
 
+import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Optional;
@@ -113,6 +114,13 @@ public class StorageManager extends ComponentManager implements Storage {
         leaveListStorage.saveLeaveList(leaveList, filePath);
     }
 
+    /**
+     * Deletes the AddressBook as specified in the UserPrefs
+     */
+    @Override
+    public void deleteAddressBook() {
+        addressBookStorage.deleteAddressBook();
+    }
 
     @Override
     @Subscribe

--- a/src/main/java/seedu/address/storage/StorageManager.java
+++ b/src/main/java/seedu/address/storage/StorageManager.java
@@ -1,6 +1,5 @@
 package seedu.address.storage;
 
-import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Optional;

--- a/src/main/java/seedu/address/storage/XmlAddressBookStorage.java
+++ b/src/main/java/seedu/address/storage/XmlAddressBookStorage.java
@@ -2,6 +2,7 @@ package seedu.address.storage;
 
 import static java.util.Objects.requireNonNull;
 
+import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -77,4 +78,10 @@ public class XmlAddressBookStorage implements AddressBookStorage {
         XmlFileStorage.saveDataToFile(filePath, new XmlSerializableAddressBook(addressBook));
     }
 
+    @Override
+    public void deleteAddressBook() {
+        File addressBookFile = new File(filePath.toUri());
+        addressBookFile.delete();
+        logger.info("data/AddressBook.xml has been deleted.");
+    }
 }


### PR DESCRIPTION
### General updates to the program
- Addresses issue where users (targeted to those from CS2113 testing the application), that do not delete the old data/AddressBook.xml prior to launching this application, will now have the file removed and will launch the application with a sample address book.
- Implemented a ParserUtil method that checks and returns true if **one and only one** prefix type is present.

Fixes #114.
Fixes #117.
Fixes #112.